### PR TITLE
Feat/enable prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,45 @@ uvicorn app.server:app --reload
 | `TOKEN_NAME`              | Name of the cookie containing the OAuth token             | _oauth2_proxy          |
 | `INCLUDE_TOOLS`           | Comma-separated list of tool name patterns to include     | ""                     |
 | `EXCLUDE_TOOLS`           | Comma-separated list of tool name patterns to exclude     | ""                     |
+| `SYSTEM_DEFINED_PROMPTS`  | <a href="#system-defined-prompts">JSON array of built-in prompts available to all users</a> | "[]"                    |
 | `MCP_ENV_*`               | Those will be passed to the MCP server process            |                        |
 | `MCP_*_DATA_ACCESS_TEMPLATE` | Template for specific data resources. See [Data Resource Templates](#data-resource-templates) for details. | `{*}/{placeholder}` |
 
+
+---
+
+## System Defined Prompts
+
+### SYSTEM_DEFINED_PROMPTS
+
+The `SYSTEM_DEFINED_PROMPTS` environment variable allows you to inject a list of built-in prompts that are available to all users, regardless of the underlying MCP server. This is useful for providing default or global prompt templates (such as greetings, onboarding, or FAQ responses) that do not depend on the MCP toolset.
+
+**Format:**
+
+Set `SYSTEM_DEFINED_PROMPTS` to a JSON array of prompt objects, each with the following fields:
+
+```json
+[
+  {
+    "name": "greeting",
+    "title": "Hello You",
+    "description": "Get a personalized greeting.",
+    "arguments": [{ "name": "name" }],
+    "template": "Hello, {name}!"
+  }
+]
+```
+
+**Fields:**
+- `name`: Unique identifier for the prompt
+- `title`: Display name
+- `description`: Short explanation of the prompt's purpose
+- `arguments`: List of argument definitions (name, type, etc.)
+- `template`: String template with placeholders for arguments
+
+These prompts are merged into the `/prompts` endpoint and can be invoked by name using the standard API. See [prompt_helper.py](app/session_manager/prompt_helper.py) for implementation details.
+
+---
 ### MCP_SERVER_COMMAND Template Placeholders
 
 The `MCP_SERVER_COMMAND` environment variable supports template placeholders that are dynamically resolved based on the user's OAuth token and requested access:

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional, Dict
+from mcp.server.fastmcp.prompts import base
 
 
 class MCPRequest(BaseModel):
@@ -51,6 +52,61 @@ def content_resolver(result, isError):
     if isError:
         return [RunToolResultContent({"text": "An error occurred"})]
     return []
+
+
+class MessageContent(BaseModel):
+    type: str
+    text: str
+
+
+class Message(BaseModel):
+    role: str
+    content: MessageContent
+
+
+class RunPromptResult(BaseModel):
+    isError: bool
+    meta: Optional[str]
+    description: Optional[str]
+    messages: list[Message]
+
+    def map_message(self, message: base.Message) -> Message:
+        content = MessageContent(
+            type=message.content.type if hasattr(message.content, "type") else "text",
+            text=(
+                message.content.text
+                if hasattr(message.content, "text")
+                else str(message.content)
+            ),
+        )
+        return Message(
+            role=message.role if hasattr(message, "role") else "unknown",
+            content=content,
+        )
+
+    def __init__(self, result):
+        print(f"[RunPromptResult] Initializing with result: {result}")
+        try:
+            super().__init__(
+                isError=False,
+                meta=result.meta if hasattr(result, "meta") else None,
+                description=(
+                    result.description if hasattr(result, "description") else None
+                ),
+                messages=(
+                    map(self.map_message, result.messages)
+                    if hasattr(result, "messages")
+                    else []
+                ),
+            )
+        except Exception as e:
+            print(f"[RunPromptResult] Error during initialization: {e}")
+            super().__init__(
+                isError=True,
+                meta=None,
+                description=f"Error processing prompt result: {e}",
+                messages=[],
+            )
 
 
 class RunToolsResult(BaseModel):

--- a/app/oauth/test_user_info_group_access.py
+++ b/app/oauth/test_user_info_group_access.py
@@ -450,37 +450,6 @@ class TestNormalizeGroups:
         assert extractor._normalize_groups("") == []
 
 
-class TestDataPathResolution:
-    """Test data path resolution functionality"""
-
-    def test_resolve_data_path_user(self, data_manager):
-        """Test resolving user-specific data path"""
-        token = create_test_token("path_user", ["group1"])
-
-        path = data_manager.resolve_data_path(token)
-
-        assert path == "/data/u/path_user.json"
-
-    def test_resolve_data_path_group(self, data_manager):
-        """Test resolving group-specific data path"""
-        token = create_test_token("path_user", ["test_group"])
-
-        path = data_manager.resolve_data_path(token, "test_group")
-
-        assert path == "/data/g/test_group.json"
-
-    def test_resolve_data_path_with_special_chars(self, data_manager):
-        """Test data path resolution with special characters"""
-        token = create_test_token("user/with/../special", ["group/with/slashes"])
-
-        user_path = data_manager.resolve_data_path(token)
-        group_path = data_manager.resolve_data_path(token, "group/with/slashes")
-
-        # The sanitizer converts "../" to "_" due to consecutive dots rule
-        assert user_path == "/data/u/userwith_special.json"
-        assert group_path == "/data/g/groupwithslashes.json"
-
-
 class TestGetUserAccessibleGroups:
     """Test getting user accessible groups with error handling"""
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse
 from typing import Optional, Dict
 import uuid
 import os
+from contextlib import asynccontextmanager
 from .session import MCPLocalSessionTask, mcp_session, try_get_session_id, session_id
 from .session_manager import session_manager
 from .models import RunToolsResult
@@ -46,8 +47,8 @@ def map_tools(tools):
         exclude_match = any(
             matches_pattern(tool.name, pattern) for pattern in EXCLUDE_TOOLS if pattern
         )
-        print(
-            f"Tool: {tool.name}, Include Match: {include_match} - {INCLUDE_TOOLS}, Exclude Match: {exclude_match} - {EXCLUDE_TOOLS}"
+        logger.debug(
+            f"[Tools] Filter check -> Tool: {tool.name}, Include Match: {include_match} - {INCLUDE_TOOLS}, Exclude Match: {exclude_match} - {EXCLUDE_TOOLS}"
         )
         if INCLUDE_TOOLS and any(INCLUDE_TOOLS) and not include_match:
             continue
@@ -72,6 +73,69 @@ def map_tools(tools):
 
 if MCP_BASE_PATH:
     router.prefix = MCP_BASE_PATH
+
+
+@asynccontextmanager
+async def mcp_session_context(x_inxm_mcp_session: Optional[str], access_token: Optional[str], group: Optional[str]):
+    """Yield a delegate with unified list_tools() and call_tool() across sessionful and sessionless modes."""
+    # Sessionless path: validate group access (if present) and open a transient MCP session
+    if x_inxm_mcp_session is None:
+        if group and access_token:
+            data_manager = get_data_access_manager()
+            try:
+                data_manager.resolve_data_resource(access_token, group)
+            except PermissionError as e:
+                logger.warning(f"Group access denied: {str(e)}")
+                raise HTTPException(status_code=403, detail=str(e))
+
+        async with mcp_session(get_server_params(access_token, group)) as session:
+            class SessionDelegate:
+                async def list_tools(self):
+                    tools = await session.list_tools()
+                    return map_tools(tools)
+
+                async def call_tool(self, tool_name: str, args: Optional[Dict], access_token_inner: Optional[str]):
+                    tools = await session.list_tools()
+                    decorated_args = await decorate_args_with_oauth_token(
+                        tools, tool_name, args, access_token_inner
+                    )
+                    result = await session.call_tool(tool_name, decorated_args)
+                    return RunToolsResult(result)
+
+            yield SessionDelegate()
+        return
+
+    # Sessionful path: reuse existing task, but surface a common delegate API
+    mcp_task = sessions.get(x_inxm_mcp_session)
+    if not mcp_task:
+        logger.warning(
+            mask_token(
+                f"[MCP] Session not found: {x_inxm_mcp_session}",
+                x_inxm_mcp_session,
+            )
+        )
+        raise HTTPException(status_code=404, detail="Session not found. It might have expired, please start a new.")
+
+    class TaskDelegate:
+        async def list_tools(self):
+            tools = await mcp_task.request("list_tools")
+            return map_tools(tools)
+
+        async def call_tool(self, tool_name: str, args: Optional[Dict], access_token_inner: Optional[str]):
+            tools = await mcp_task.request("list_tools")
+            decorated_args = await decorate_args_with_oauth_token(
+                tools, tool_name, args, access_token_inner
+            )
+            result = await mcp_task.request(
+                {"action": "run_tool", "tool_name": tool_name, "args": decorated_args}
+            )
+            return RunToolsResult(result)
+
+    try:
+        yield TaskDelegate()
+    finally:
+        # No-op: persistent session remains managed elsewhere
+        pass
 
 
 @router.get("/tools")
@@ -101,40 +165,15 @@ async def list_tools(
                     x_inxm_mcp_session,
                 )
             )
-            if x_inxm_mcp_session is None:
-                # Validate group access for sessionless requests
-                if group and access_token:
-                    data_manager = get_data_access_manager()
-                    try:
-                        data_manager.resolve_data_resource(access_token, group)
-                    except PermissionError as e:
-                        logger.warning(f"Group access denied in list_tools: {str(e)}")
-                        raise HTTPException(status_code=403, detail=str(e))
-
-                async with mcp_session(
-                    get_server_params(access_token, group)
-                ) as session:
-                    result = await session.list_tools()
-                    logger.debug("[Tools] Tools listed without session.")
-                    return map_tools(result)
-
-            mcp_task = sessions.get(x_inxm_mcp_session)
-            if not mcp_task:
-                logger.warning(
+            async with mcp_session_context(x_inxm_mcp_session, access_token, group) as session:
+                result = await session.list_tools()
+                logger.debug(
                     mask_token(
-                        f"[Tools] Session not found: {x_inxm_mcp_session}",
+                        f"[Tools] Tools listed. Session: {x_inxm_mcp_session}",
                         x_inxm_mcp_session,
                     )
                 )
-                raise HTTPException(status_code=404, detail="Session not found")
-            result = await mcp_task.request("list_tools")
-            logger.debug(
-                mask_token(
-                    f"[Tools] Tools listed for session {x_inxm_mcp_session}.",
-                    x_inxm_mcp_session,
-                )
-            )
-            return map_tools(result)
+                return result
     except UserLoggedOutException as e:
         logger.warning(f"[Tools] Unauthorized access: {str(e)}")
         raise HTTPException(status_code=401, detail=e.message)
@@ -177,52 +216,8 @@ async def run_tool(
                     x_inxm_mcp_session,
                 )
             )
-            if x_inxm_mcp_session is None:
-                # Validate group access for sessionless requests
-                if group and access_token:
-                    data_manager = get_data_access_manager()
-                    try:
-                        data_manager.resolve_data_resource(access_token, group)
-                    except PermissionError as e:
-                        logger.warning(f"Group access denied in run_tool: {str(e)}")
-                        raise HTTPException(status_code=403, detail=str(e))
-
-                async with mcp_session(
-                    get_server_params(access_token, group)
-                ) as session:
-                    tools = await session.list_tools()
-                    decorated_args = await decorate_args_with_oauth_token(
-                        tools, tool_name, args, access_token
-                    )
-                    result = await session.call_tool(tool_name, decorated_args)
-                    result = RunToolsResult(result)
-            else:
-                mcp_task = sessions.get(x_inxm_mcp_session)
-                if not mcp_task:
-                    logger.warning(
-                        mask_token(
-                            f"[Tool-Call] Session not found: {x_inxm_mcp_session}",
-                            x_inxm_mcp_session,
-                        )
-                    )
-                    raise HTTPException(
-                        status_code=404,
-                        detail="Session not found. It might have expired, please start a new.",
-                    )
-                else:
-                    tools = await mcp_task.request("list_tools")
-                    decorated_args = await decorate_args_with_oauth_token(
-                        tools, tool_name, args, access_token
-                    )
-                    result = RunToolsResult(
-                        await mcp_task.request(
-                            {
-                                "action": "run_tool",
-                                "tool_name": tool_name,
-                                "args": decorated_args,
-                            }
-                        )
-                    )
+            async with mcp_session_context(x_inxm_mcp_session, access_token, group) as session:
+                result = await session.call_tool(tool_name, args, access_token)
 
         logger.info(f"[Tool-Call] Tool {tool_name} called. Result: {result}")
         if result.isError:

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,14 +4,12 @@ from fastapi.responses import JSONResponse
 from typing import Optional, Dict
 import uuid
 import os
-from contextlib import asynccontextmanager
-from .session import MCPLocalSessionTask, mcp_session, try_get_session_id, session_id
-from .session_manager import session_manager
-from .models import RunToolsResult
+
+from app.utils.traced_requests import traced_request
+from app.session import MCPLocalSessionTask, try_get_session_id, session_id
+from app.session_manager import mcp_session_context, session_manager
 from .mcp_server import get_server_params
-from .oauth.decorator import decorate_args_with_oauth_token
 from .oauth.user_info import get_data_access_manager
-from fnmatch import fnmatch
 from opentelemetry import trace
 from .oauth.token_exchange import UserLoggedOutException
 from .utils import mask_token
@@ -30,112 +28,8 @@ EXCLUDE_TOOLS = [t for t in os.environ.get("EXCLUDE_TOOLS", "").split(",") if t]
 
 tracer = trace.get_tracer(__name__)
 
-
-def matches_pattern(value, pattern):
-    """Check if a value matches a glob-like pattern."""
-    return fnmatch(value, pattern)
-
-
-def map_tools(tools):
-    """Map tools with INCLUDE_TOOLS and EXCLUDE_TOOLS filters applied."""
-
-    filtered_tools = []
-    for tool in tools.tools:
-        include_match = any(
-            matches_pattern(tool.name, pattern) for pattern in INCLUDE_TOOLS if pattern
-        )
-        exclude_match = any(
-            matches_pattern(tool.name, pattern) for pattern in EXCLUDE_TOOLS if pattern
-        )
-        logger.debug(
-            f"[Tools] Filter check -> Tool: {tool.name}, Include Match: {include_match} - {INCLUDE_TOOLS}, Exclude Match: {exclude_match} - {EXCLUDE_TOOLS}"
-        )
-        if INCLUDE_TOOLS and any(INCLUDE_TOOLS) and not include_match:
-            continue
-        if EXCLUDE_TOOLS and any(EXCLUDE_TOOLS) and exclude_match:
-            continue
-
-        filtered_tools.append(
-            {
-                "name": tool.name,
-                "title": tool.title,
-                "description": tool.description,
-                "inputSchema": tool.inputSchema,
-                "outputSchema": tool.outputSchema,
-                "annotations": tool.annotations,
-                "meta": tool.meta,
-                "url": f"{MCP_BASE_PATH}/tools/{tool.name}",
-            }
-        )
-
-    return filtered_tools
-
-
 if MCP_BASE_PATH:
     router.prefix = MCP_BASE_PATH
-
-
-@asynccontextmanager
-async def mcp_session_context(x_inxm_mcp_session: Optional[str], access_token: Optional[str], group: Optional[str]):
-    """Yield a delegate with unified list_tools() and call_tool() across sessionful and sessionless modes."""
-    # Sessionless path: validate group access (if present) and open a transient MCP session
-    if x_inxm_mcp_session is None:
-        if group and access_token:
-            data_manager = get_data_access_manager()
-            try:
-                data_manager.resolve_data_resource(access_token, group)
-            except PermissionError as e:
-                logger.warning(f"Group access denied: {str(e)}")
-                raise HTTPException(status_code=403, detail=str(e))
-
-        async with mcp_session(get_server_params(access_token, group)) as session:
-            class SessionDelegate:
-                async def list_tools(self):
-                    tools = await session.list_tools()
-                    return map_tools(tools)
-
-                async def call_tool(self, tool_name: str, args: Optional[Dict], access_token_inner: Optional[str]):
-                    tools = await session.list_tools()
-                    decorated_args = await decorate_args_with_oauth_token(
-                        tools, tool_name, args, access_token_inner
-                    )
-                    result = await session.call_tool(tool_name, decorated_args)
-                    return RunToolsResult(result)
-
-            yield SessionDelegate()
-        return
-
-    # Sessionful path: reuse existing task, but surface a common delegate API
-    mcp_task = sessions.get(x_inxm_mcp_session)
-    if not mcp_task:
-        logger.warning(
-            mask_token(
-                f"[MCP] Session not found: {x_inxm_mcp_session}",
-                x_inxm_mcp_session,
-            )
-        )
-        raise HTTPException(status_code=404, detail="Session not found. It might have expired, please start a new.")
-
-    class TaskDelegate:
-        async def list_tools(self):
-            tools = await mcp_task.request("list_tools")
-            return map_tools(tools)
-
-        async def call_tool(self, tool_name: str, args: Optional[Dict], access_token_inner: Optional[str]):
-            tools = await mcp_task.request("list_tools")
-            decorated_args = await decorate_args_with_oauth_token(
-                tools, tool_name, args, access_token_inner
-            )
-            result = await mcp_task.request(
-                {"action": "run_tool", "tool_name": tool_name, "args": decorated_args}
-            )
-            return RunToolsResult(result)
-
-    try:
-        yield TaskDelegate()
-    finally:
-        # No-op: persistent session remains managed elsewhere
-        pass
 
 
 @router.get("/tools")
@@ -148,24 +42,20 @@ async def list_tools(
     ),
 ):
     try:
-        with tracer.start_as_current_span("list_tools") as span:
-            x_inxm_mcp_session = session_id(
-                try_get_session_id(
-                    x_inxm_mcp_session_header, x_inxm_mcp_session_cookie
-                ),
-                access_token,
-            )
-            if x_inxm_mcp_session:
-                span.set_attribute("session.id", x_inxm_mcp_session)
-            if group:
-                span.set_attribute("session.group", group)
-            logger.info(
-                mask_token(
-                    f"[Tools] Listing tools. Session: {x_inxm_mcp_session}, Group: {group}",
-                    x_inxm_mcp_session,
-                )
-            )
-            async with mcp_session_context(x_inxm_mcp_session, access_token, group) as session:
+        x_inxm_mcp_session = session_id(
+            try_get_session_id(x_inxm_mcp_session_header, x_inxm_mcp_session_cookie),
+            access_token,
+        )
+        with traced_request(
+            tracer,
+            operation="list_tools",
+            session_value=x_inxm_mcp_session,
+            group=group,
+            start_message=f"[Tools] Listing tools. Session: {x_inxm_mcp_session}, Group: {group}",
+        ):
+            async with mcp_session_context(
+                sessions, x_inxm_mcp_session, access_token, group
+            ) as session:
                 result = await session.list_tools()
                 logger.debug(
                     mask_token(
@@ -192,31 +82,28 @@ async def run_tool(
     ),
 ):
     try:
-        with tracer.start_as_current_span(
-            "run_tool", attributes={"tool.name": tool_name}
-        ) as span:
-            x_inxm_mcp_session = session_id(
-                try_get_session_id(
-                    x_inxm_mcp_session_header,
-                    x_inxm_mcp_session_cookie,
-                    args.get("inxm-session", None) if args else None,
-                ),
-                access_token,
-            )
-            if x_inxm_mcp_session:
-                span.set_attribute("session.id", x_inxm_mcp_session)
-            if group:
-                span.set_attribute("session.group", group)
-            if args and "inxm-session" in args:
-                args = dict(args)
-                args.pop("inxm-session")
-            logger.info(
-                mask_token(
-                    f"[Tool-Call] Tool call: {tool_name}, Session: {x_inxm_mcp_session}, Group: {group}, Args: {args}",
-                    x_inxm_mcp_session,
-                )
-            )
-            async with mcp_session_context(x_inxm_mcp_session, access_token, group) as session:
+        x_inxm_mcp_session = session_id(
+            try_get_session_id(
+                x_inxm_mcp_session_header,
+                x_inxm_mcp_session_cookie,
+                args.get("inxm-session", None) if args else None,
+            ),
+            access_token,
+        )
+        if args and "inxm-session" in args:
+            args = dict(args)
+            args.pop("inxm-session")
+        with traced_request(
+            tracer=tracer,
+            operation="run_tool",
+            session_value=x_inxm_mcp_session,
+            group=group,
+            start_message=f"[Tool-Call] Tool call: {tool_name}, Session: {x_inxm_mcp_session}, Group: {group}, Args: {args}",
+            extra_attrs={"tool.name": tool_name},
+        ):
+            async with mcp_session_context(
+                sessions, x_inxm_mcp_session, access_token, group
+            ) as session:
                 result = await session.call_tool(tool_name, args, access_token)
 
         logger.info(f"[Tool-Call] Tool {tool_name} called. Result: {result}")

--- a/app/session/session.py
+++ b/app/session/session.py
@@ -128,6 +128,29 @@ class MCPLocalSessionTask(MCPSessionBase):
                                 logger, "[MCPLocalSessionTask]", e
                             )
                             await self.response_queue.put({"error": str(e)})
+                    elif req == "list_prompts":
+                        logger.debug("[MCPLocalSessionTask] Listing available prompts.")
+                        try:
+                            result = await session.list_prompts()
+                            await self.response_queue.put(result)
+                        except Exception as e:
+                            log_exception_with_details(
+                                logger, "[MCPLocalSessionTask]", e
+                            )
+                    elif isinstance(req, dict) and req.get("action") == "get_prompt":
+                        prompt_name = req["prompt_name"]
+                        args = req.get("args", {})
+                        logger.info(
+                            f"[MCPLocalSessionTask] Running prompt: {prompt_name} with args: {args}"
+                        )
+                        try:
+                            result = await session.get_prompt(prompt_name, args)
+                            await self.response_queue.put(result)
+                        except Exception as e:
+                            log_exception_with_details(
+                                logger, "[MCPLocalSessionTask]", e
+                            )
+                            await self.response_queue.put({"error": str(e)})
                     elif isinstance(req, dict) and req.get("action") == "run_tool":
                         tool_name = req["tool_name"]
                         args = req.get("args", {})

--- a/app/session_manager/__init__.py
+++ b/app/session_manager/__init__.py
@@ -1,3 +1,4 @@
 from .session_manager import session_manager
+from .session_context import mcp_session_context
 
-__all__ = ["session_manager"]
+__all__ = ["session_manager", "mcp_session_context"]

--- a/app/session_manager/prompt_helper.py
+++ b/app/session_manager/prompt_helper.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+import json
+import logging
+import os
+from typing import Optional
+
+from fastapi import HTTPException
+
+from app.models import RunPromptResult
+
+
+logger = logging.getLogger("uvicorn.error")
+
+
+@dataclass
+class Template:
+    role: str
+    content: str
+
+
+@dataclass
+class Prompt:
+    name: str
+    title: str
+    description: str
+    arguments: list[dict]
+    template: str
+
+
+def default_prompt_list_result(prompts: list[Prompt] = []):
+    return {
+        "_meta": None,
+        "nextCursor": None,
+        "prompts": [
+            {k: v for k, v in prompt.__dict__.items() if k != "template"}
+            for prompt in prompts
+        ],
+    }
+
+
+def system_defined_prompts() -> list[Prompt]:
+    # System defined prompt looks like this:
+    # { "name": "greeting", "title": "Hello You", "description": "Get a personalized greeting.", "arguments": [{ "name": "name" }], "template": "Hello, {name}!" }
+    prompts = json.loads(os.environ.get("SYSTEM_DEFINED_PROMPTS", "[]"))
+    return [Prompt(**p) for p in prompts]
+
+
+async def list_prompts(list_prompts: any):
+    system_prompts = system_defined_prompts()
+    try:
+        prompts = await list_prompts()
+        prompts.prompts += [
+            {k: v for k, v in prompt.__dict__.items() if k != "template"}
+            for prompt in system_prompts
+        ]
+    except Exception as e:
+        logger.error(f"Error listing prompts: {str(e)}")
+        # Not every MCP has list_prompts, so deal with it friendly
+        if (
+            hasattr(e, "__class__")
+            and e.__class__.__name__ == "McpError"
+            and "Method not found" in str(e)
+        ):
+            if len(system_prompts) < 1:
+                raise HTTPException(status_code=404, detail="Method not found")
+            else:
+                prompts = default_prompt_list_result(system_prompts)
+        else:
+            raise HTTPException(status_code=500, detail="Loading prompts failed")
+    return prompts
+
+
+async def call_prompt(call: any, prompt_name: str, args: Optional[dict] = []):
+    system_prompts = system_defined_prompts()
+    prompt = next((p for p in system_prompts if p.name == prompt_name), None)
+    if prompt:
+        logger.info(f"Using system prompt: {prompt.name}")
+        expanded = prompt.template["content"].format(**args)
+
+        class SystemDefinedPromptResult:
+            def __init__(self, description, messages):
+                self.description = description
+                self.messages = messages
+
+        return RunPromptResult(
+            SystemDefinedPromptResult(
+                description=prompt.description,
+                messages=[Template(content=expanded, role=prompt.template["role"])],
+            )
+        )
+
+    # Call the prompt with the provided arguments
+    logger.info(f"Calling prompt: {prompt_name} with args: {args}")
+    return await call(prompt_name, args)

--- a/app/session_manager/session_context.py
+++ b/app/session_manager/session_context.py
@@ -1,0 +1,143 @@
+import logging
+from fastapi import HTTPException
+from typing import Optional, Dict
+import os
+from contextlib import asynccontextmanager
+
+from app.session import mcp_session
+from app.session_manager.session_manager import SessionManagerBase
+from app.models import RunToolsResult
+from app.mcp_server import get_server_params
+from fnmatch import fnmatch
+from app.oauth.decorator import decorate_args_with_oauth_token
+from app.oauth.user_info import get_data_access_manager
+from app.utils import mask_token
+
+
+logger = logging.getLogger("uvicorn.error")
+
+INCLUDE_TOOLS = [t for t in os.environ.get("INCLUDE_TOOLS", "").split(",") if t]
+EXCLUDE_TOOLS = [t for t in os.environ.get("EXCLUDE_TOOLS", "").split(",") if t]
+MCP_BASE_PATH = os.environ.get("MCP_BASE_PATH", "")
+
+
+def matches_pattern(value, pattern):
+    """Check if a value matches a glob-like pattern."""
+    return fnmatch(value, pattern)
+
+
+def map_tools(tools):
+    """Map tools with INCLUDE_TOOLS and EXCLUDE_TOOLS filters applied."""
+
+    filtered_tools = []
+    for tool in tools.tools:
+        include_match = any(
+            matches_pattern(tool.name, pattern) for pattern in INCLUDE_TOOLS if pattern
+        )
+        exclude_match = any(
+            matches_pattern(tool.name, pattern) for pattern in EXCLUDE_TOOLS if pattern
+        )
+        logger.debug(
+            f"[Tools] Filter check -> Tool: {tool.name}, Include Match: {include_match} - {INCLUDE_TOOLS}, Exclude Match: {exclude_match} - {EXCLUDE_TOOLS}"
+        )
+        if INCLUDE_TOOLS and any(INCLUDE_TOOLS) and not include_match:
+            continue
+        if EXCLUDE_TOOLS and any(EXCLUDE_TOOLS) and exclude_match:
+            continue
+
+        filtered_tools.append(
+            {
+                "name": tool.name,
+                "title": tool.title,
+                "description": tool.description,
+                "inputSchema": tool.inputSchema,
+                "outputSchema": tool.outputSchema,
+                "annotations": tool.annotations,
+                "meta": tool.meta,
+                "url": f"{MCP_BASE_PATH}/tools/{tool.name}",
+            }
+        )
+
+    return filtered_tools
+
+
+@asynccontextmanager
+async def mcp_session_context(
+    sessions: SessionManagerBase,
+    x_inxm_mcp_session: Optional[str],
+    access_token: Optional[str],
+    group: Optional[str],
+):
+    """Yield a delegate with unified list_tools() and call_tool() across sessionful and sessionless modes."""
+    # Sessionless path: validate group access (if present) and open a transient MCP session
+    if x_inxm_mcp_session is None:
+        if group and access_token:
+            data_manager = get_data_access_manager()
+            try:
+                data_manager.resolve_data_resource(access_token, group)
+            except PermissionError as e:
+                logger.warning(f"Group access denied: {str(e)}")
+                raise HTTPException(status_code=403, detail=str(e))
+
+        async with mcp_session(get_server_params(access_token, group)) as session:
+
+            class SessionDelegate:
+                async def list_tools(self):
+                    tools = await session.list_tools()
+                    return map_tools(tools)
+
+                async def call_tool(
+                    self,
+                    tool_name: str,
+                    args: Optional[Dict],
+                    access_token_inner: Optional[str],
+                ):
+                    tools = await session.list_tools()
+                    decorated_args = await decorate_args_with_oauth_token(
+                        tools, tool_name, args, access_token_inner
+                    )
+                    result = await session.call_tool(tool_name, decorated_args)
+                    return RunToolsResult(result)
+
+            yield SessionDelegate()
+        return
+
+    # Sessionful path: reuse existing task, but surface a common delegate API
+    mcp_task = sessions.get(x_inxm_mcp_session)
+    if not mcp_task:
+        logger.warning(
+            mask_token(
+                f"[MCP] Session not found: {x_inxm_mcp_session}",
+                x_inxm_mcp_session,
+            )
+        )
+        raise HTTPException(
+            status_code=404,
+            detail="Session not found. It might have expired, please start a new.",
+        )
+
+    class TaskDelegate:
+        async def list_tools(self):
+            tools = await mcp_task.request("list_tools")
+            return map_tools(tools)
+
+        async def call_tool(
+            self,
+            tool_name: str,
+            args: Optional[Dict],
+            access_token_inner: Optional[str],
+        ):
+            tools = await mcp_task.request("list_tools")
+            decorated_args = await decorate_args_with_oauth_token(
+                tools, tool_name, args, access_token_inner
+            )
+            result = await mcp_task.request(
+                {"action": "run_tool", "tool_name": tool_name, "args": decorated_args}
+            )
+            return RunToolsResult(result)
+
+    try:
+        yield TaskDelegate()
+    finally:
+        # No-op: persistent session remains managed elsewhere
+        pass

--- a/app/session_manager/test_map_tools.py
+++ b/app/session_manager/test_map_tools.py
@@ -1,5 +1,5 @@
 import pytest
-from app.routes import map_tools
+from app.session_manager.session_context import map_tools
 from unittest.mock import patch
 
 
@@ -35,7 +35,9 @@ def mock_tools():
 
 
 def test_works_without_filters(mock_tools):
-    with patch("app.routes.INCLUDE_TOOLS", []), patch("app.routes.EXCLUDE_TOOLS", []):
+    with patch("app.session_manager.session_context.INCLUDE_TOOLS", []), patch(
+        "app.session_manager.session_context.EXCLUDE_TOOLS", []
+    ):
         result = map_tools(mock_tools)
         assert len(result) == 3
         assert all(
@@ -44,8 +46,8 @@ def test_works_without_filters(mock_tools):
 
 
 def test_include_tools(mock_tools):
-    with patch("app.routes.INCLUDE_TOOLS", ["tool*"]), patch(
-        "app.routes.EXCLUDE_TOOLS", []
+    with patch("app.session_manager.session_context.INCLUDE_TOOLS", ["tool*"]), patch(
+        "app.session_manager.session_context.EXCLUDE_TOOLS", []
     ):
         result = map_tools(mock_tools)
         assert len(result) == 2
@@ -53,8 +55,8 @@ def test_include_tools(mock_tools):
 
 
 def test_exclude_tools(mock_tools):
-    with patch("app.routes.INCLUDE_TOOLS", []), patch(
-        "app.routes.EXCLUDE_TOOLS", ["tool*"]
+    with patch("app.session_manager.session_context.INCLUDE_TOOLS", []), patch(
+        "app.session_manager.session_context.EXCLUDE_TOOLS", ["tool*"]
     ):
         result = map_tools(mock_tools)
         assert len(result) == 1
@@ -62,8 +64,8 @@ def test_exclude_tools(mock_tools):
 
 
 def test_include_and_exclude_tools(mock_tools):
-    with patch("app.routes.INCLUDE_TOOLS", ["*"]), patch(
-        "app.routes.EXCLUDE_TOOLS", ["special*"]
+    with patch("app.session_manager.session_context.INCLUDE_TOOLS", ["*"]), patch(
+        "app.session_manager.session_context.EXCLUDE_TOOLS", ["special*"]
     ):
         result = map_tools(mock_tools)
         assert len(result) == 2

--- a/app/session_manager/test_prompt_helper.py
+++ b/app/session_manager/test_prompt_helper.py
@@ -1,0 +1,133 @@
+import os
+import json
+import pytest
+from fastapi import HTTPException
+from app.session_manager import prompt_helper
+
+
+class DummyCall:
+    def __init__(self, result=None, error=None):
+        self.result = result
+        self.error = error
+
+    async def __call__(self, prompt_name, args):
+        if self.error:
+            raise self.error
+        return self.result
+
+
+class DummyListPrompts:
+    def __init__(self, result=None, error=None):
+        self.result = result
+        self.error = error
+
+    async def __call__(self):
+        if self.error:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def clear_env():
+    os.environ.pop("SYSTEM_DEFINED_PROMPTS", None)
+    yield
+    os.environ.pop("SYSTEM_DEFINED_PROMPTS", None)
+
+
+@pytest.fixture
+def system_prompts():
+    prompts = [
+        {
+            "name": "greeting",
+            "title": "Hello You",
+            "description": "Get a personalized greeting.",
+            "arguments": [{"name": "name"}],
+            "template": {"role": "system", "content": "Hello, {name}!"},
+        }
+    ]
+    os.environ["SYSTEM_DEFINED_PROMPTS"] = json.dumps(prompts)
+    return [prompt_helper.Prompt(**p) for p in prompts]
+
+
+def test_default_prompt_list_result(system_prompts):
+    result = prompt_helper.default_prompt_list_result(system_prompts)
+    assert "prompts" in result
+    assert result["prompts"][0]["name"] == "greeting"
+    assert "template" not in result["prompts"][0]
+
+
+def test_system_defined_prompts(system_prompts):
+    prompts = prompt_helper.system_defined_prompts()
+    assert len(prompts) == 1
+    assert prompts[0].name == "greeting"
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_merges_system_prompts(system_prompts):
+    class ListPromptsResult:
+        def __init__(self):
+            self.prompts = []
+
+    async def list_prompts():
+        return ListPromptsResult()
+
+    result = await prompt_helper.list_prompts(list_prompts)
+    # result is ListPromptsResult, check its .prompts attribute
+    assert any(p["name"] == "greeting" for p in result.prompts)
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_mcp_error_method_not_found(system_prompts):
+    class McpError(Exception):
+        pass
+
+    McpError.__name__ = "McpError"
+
+    async def list_prompts():
+        raise McpError("Method not found")
+
+    result = await prompt_helper.list_prompts(list_prompts)
+    assert any(p["name"] == "greeting" for p in result["prompts"])
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_mcp_error_method_not_found_no_system():
+    async def list_prompts():
+        class McpError(Exception):
+            pass
+
+        McpError.__name__ = "McpError"
+        raise McpError("Method not found")
+
+    with pytest.raises(HTTPException) as exc:
+        await prompt_helper.list_prompts(list_prompts)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_other_error():
+    async def list_prompts():
+        raise Exception("Other error")
+
+    with pytest.raises(HTTPException) as exc:
+        await prompt_helper.list_prompts(list_prompts)
+    assert exc.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_call_prompt_system_defined(system_prompts):
+    args = {"name": "World"}
+    result = await prompt_helper.call_prompt(lambda n, a: None, "greeting", args)
+    print(f"Result: {result}")
+    assert result.description == "Get a personalized greeting."
+    assert not result.isError
+    assert result.messages[0].content.text == "Hello, World!"
+
+
+@pytest.mark.asyncio
+async def test_call_prompt_delegates_to_call():
+    async def call(prompt_name, args):
+        return "called"
+
+    result = await prompt_helper.call_prompt(call, "not_found", {})
+    assert result == "called"

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -70,10 +70,22 @@ def test_tools_loaded(test_client):
     suite.test_tools_loaded()
 
 
+def test_prompts_loaded(test_client):
+    client, base_url = test_client
+    suite = FastAPIWrapper(client, base_url)
+    suite.test_prompts_loaded()
+
+
 def test_call_tool(test_client):
     client, base_url = test_client
     suite = FastAPIWrapper(client, base_url)
     suite.test_call_tool()
+
+
+def test_call_prompt(test_client):
+    client, base_url = test_client
+    suite = FastAPIWrapper(client, base_url)
+    suite.test_call_prompt()
 
 
 def test_tool_wrong_args(test_client):
@@ -104,3 +116,9 @@ def test_counts_up_in_a_session_correctly(test_client):
     client, base_url = test_client
     suite = FastAPIWrapper(client, base_url)
     suite.test_counts_up_in_a_session_correctly()
+
+
+def test_prompts_in_a_session_doesnt_do_anything_but_it_should_work(test_client):
+    client, base_url = test_client
+    suite = FastAPIWrapper(client, base_url)
+    suite.test_prompts_in_a_session_doesnt_do_anything_but_it_should_work()

--- a/app/test_fastapi_with_testclient.py
+++ b/app/test_fastapi_with_testclient.py
@@ -18,6 +18,16 @@ def test_tools_loaded(test_client):
     suite.test_tools_loaded()
 
 
+def test_prompts_loaded(test_client):
+    suite = FastAPIWrapper(test_client)
+    suite.test_prompts_loaded()
+
+
+def test_call_prompt(test_client):
+    suite = FastAPIWrapper(test_client)
+    suite.test_call_prompt()
+
+
 def test_call_tool(test_client):
     suite = FastAPIWrapper(test_client)
     suite.test_call_tool()
@@ -46,3 +56,8 @@ def test_non_existing_tool(test_client):
 def test_counts_up_in_a_session_correctly(test_client):
     suite = FastAPIWrapper(test_client)
     suite.test_counts_up_in_a_session_correctly()
+
+
+def test_prompts_in_a_session_doesnt_do_anything_but_it_should_work(test_client):
+    suite = FastAPIWrapper(test_client)
+    suite.test_prompts_in_a_session_doesnt_do_anything_but_it_should_work()

--- a/app/utils/exception_logging.py
+++ b/app/utils/exception_logging.py
@@ -43,6 +43,39 @@ def _safe_get_exceptions(exception_group) -> list:
         return []
 
 
+def find_exception_in_exception_groups(exception: Exception, target_type: any):
+    """
+    Recursively search through an exception and its sub-exceptions to find
+    if any exception is of the target type.
+
+    Args:
+        exception: The exception to search through
+        target_type: The exception type to look for
+
+    Returns:
+        The first exception matching the target type, or None if not found
+    """
+    try:
+        print(f"Searching for {target_type.__name__} in exception: {exception}")
+        if isinstance(exception, target_type):
+            print(f"Found {target_type.__name__} in exception: {exception}")
+            return exception
+
+        # Check for sub-exceptions if this is an exception group
+        if hasattr(exception, "exceptions"):
+            sub_exceptions = _safe_get_exceptions(exception)
+            for sub_exc in sub_exceptions:
+                inner_exc = find_exception_in_exception_groups(sub_exc, target_type)
+                if inner_exc is not None:
+                    print(f"Found {target_type.__name__} in sub-exception: {inner_exc}")
+                    return inner_exc
+
+        return None
+    except Exception:
+        # If anything goes wrong, we assume we didn't find the target type
+        return None
+
+
 def log_exception_with_details(
     logger: logging.Logger,
     prefix: str,

--- a/app/utils/traced_requests.py
+++ b/app/utils/traced_requests.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Dict
 from contextlib import contextmanager
 
-from opentracing import Tracer
+from opentelemetry.trace import Tracer
 
 from app.utils import mask_token
 

--- a/app/utils/traced_requests.py
+++ b/app/utils/traced_requests.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Optional, Dict
+from contextlib import contextmanager
+
+from opentracing import Tracer
+
+from app.utils import mask_token
+
+logger = logging.getLogger("uvicorn.error")
+
+
+@contextmanager
+def traced_request(
+    tracer: Tracer,
+    operation: str,
+    session_value: Optional[str],
+    group: Optional[str],
+    start_message: str,
+    extra_attrs: Optional[Dict] = None,
+):
+    """Context manager to create a span, set common attributes, and log a start message."""
+    with tracer.start_as_current_span(operation) as span:
+        if session_value:
+            span.set_attribute("session.id", session_value)
+        if group:
+            span.set_attribute("session.group", group)
+        if extra_attrs:
+            for k, v in extra_attrs.items():
+                span.set_attribute(k, v)
+        logger.info(mask_token(start_message, session_value))
+        yield span

--- a/example/memory-group-access/web/index.html
+++ b/example/memory-group-access/web/index.html
@@ -229,6 +229,7 @@
             <div class="tabs">
                 <div class="tab active" onclick="showTab('session', this)">Session Management</div>
                 <div class="tab" onclick="showTab('tools', this)">List Tools</div>
+                <div class="tab" onclick="showTab('prompts', this)">List Prompts</div>
                 <div class="tab" onclick="showTab('memory', this)">Add Memory</div>
                 <div class="tab" onclick="showTab('search', this)">Search Memory</div>
                 <div class="tab" onclick="showTab('remove', this)">Remove Memory</div>
@@ -268,6 +269,16 @@
                     <button type="submit" class="btn btn-primary">List Tools</button>
                 </form>
                 <div id="toolsResponse" class="response-box" style="display: none;"></div>
+            </div>
+            <div id="prompts" class="tab-content">
+                <h3>2. List Prompts</h3>
+                <form id="promptForm" class="inline-form">
+                    <div class="form-group">
+                        <label for="promptGroup">Prompts:</label>
+                    </div>
+                    <button type="submit" class="btn btn-primary">List Prompts</button>
+                </form>
+                <div id="promptResponse" class="response-box" style="display: none;"></div>
             </div>
 
             <div id="memory" class="tab-content">
@@ -574,6 +585,21 @@
             
             const response = await makeRequest(url, { method: 'GET' });
             displayResponse('toolsResponse', response);
+        });
+
+        // Prompt form handler
+        document.getElementById('promptForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            if (!isAuthenticated) {
+                alert('Please login first');
+                return;
+            }
+            
+            const formData = new FormData(e.target);
+            
+            let url = '/api/mcp/memory/prompts';
+            const response = await makeRequest(url, { method: 'GET' });
+            displayResponse('promptResponse', response);
         });
 
         // Memory form handler (uses observations under the hood)

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+git pull origin main
+
 # Get the current version from pyproject.toml
 current_version=$(grep -oP '(?<=version = ")[^"]*' ./app/pyproject.toml)
 echo "Current version: $current_version"


### PR DESCRIPTION
Exposes prompts via `/prompts` and `/prompts/<name>`

Prompts are reusable templates that help LLMs interact with the server effectively. As not every MCP has a Prompt, on deployment the env variable `SYSTEM_DEFINED_PROMPTS` can be defined to inject your own. 

Fixes #1 

