### PR TITLE
fix: strip <navigate> tag and content from agent context in strip_tags

### DIFF
--- a/app/tgi/workflows/tag_parser.py
+++ b/app/tgi/workflows/tag_parser.py
@@ -70,9 +70,15 @@ def extract_return_values(text: str) -> list[tuple[str, str]]:
 def strip_tags(text: str) -> str:
     """Remove workflow control tags from text."""
     stripped = re.sub(
-        r"<(/?)(reroute|user_feedback_needed|user_feedback|passthrough)([^>]*)>",
+        r"<navigate>[\s\S]*?</navigate>",
         "",
         text or "",
+        flags=re.IGNORECASE,
+    )
+    stripped = re.sub(
+        r"<(/?)(reroute|user_feedback_needed|user_feedback|passthrough|navigate)([^>]*)>",
+        "",
+        stripped,
     )
     stripped = re.sub(
         r"<return\b[^>]*>(.*?)</return>",

--- a/app/tgi/workflows/test_agent.py
+++ b/app/tgi/workflows/test_agent.py
@@ -630,6 +630,17 @@ class TestPassthroughTagExtraction:
         assert "content" in result
         assert "reason" in result
 
+    def test_strip_tags_removes_navigate_block(self):
+        """strip_tags removes the entire <navigate> block including URL content."""
+        from app.tgi.workflows.tag_parser import strip_tags
+
+        text = "Some text <navigate>#/plan/abc-123</navigate> more text"
+        result = strip_tags(text)
+        assert result == "Some text  more text"
+        assert "#/plan/abc-123" not in result
+        assert "<navigate>" not in result
+        assert "</navigate>" not in result
+
 
 # ============================================================================
 # Integration tests with WorkflowEngine


### PR DESCRIPTION
## Summary

- Add full-block strip for `<navigate>...</navigate>` so URL fragments like `#/plan/abc-123` do not survive into agent context
- Add `navigate` to the marker-stripping regex for stray open/close tags
- Extend `strip_tags` unit test with navigate block test case

Closes iemb-91x

🤖 Merged by [Claude Code](https://claude.com/claude-code) (Refinery)