### PR TITLE
fix: reset _running flag on exception in get_agent_card

### DIFF
--- a/app/well_known/agent.py
+++ b/app/well_known/agent.py
@@ -114,117 +114,119 @@ async def get_agent_card():
         _running = True
         span.set_attribute("agent_card.cache.hit", False)
 
-        llm = LLMClient()
+        try:
+            llm = LLMClient()
 
-        async with mcp_session(anon=True) as session:
-            tools = map_tools(await session.list_tools())
+            async with mcp_session(anon=True) as session:
+                tools = map_tools(await session.list_tools())
 
-            tools_descriptions = [tool["description"] for tool in tools]
+                tools_descriptions = [tool["description"] for tool in tools]
 
-            base_request = ChatCompletionRequest(model=DEFAULT_MODEL, messages=[])
+                base_request = ChatCompletionRequest(model=DEFAULT_MODEL, messages=[])
 
-            summary = await llm.ask(
-                base_prompt="You are an MCP concise summarization engine. Summarize the following content, suitable for a service description, giving a good overview of the different tools and capabilities. Return only the summary.",
-                question="Summarize the following description: "
-                + "\n".join(tools_descriptions),
-                base_request=base_request,
-                outer_span=span,
-            )
-
-            # Base agent card
-            agent_card = {
-                "name": SERVICE_NAME,
-                "description": get_description(summary),
-                "url": f"https://{HOST}{':' + str(PORT) if PORT else ''}{MCP_BASE_PATH}/tgi/v1/a2a",
-                "version": "1.0.0",
-                "capabilities": {"streaming": True, "pushNotifications": False},
-                "authentication": {"schemes": ["bearer"] if OAUTH_ENV else []},
-                "defaultInputModes": ["data"],
-                "defaultOutputModes": ["text", "data"],
-                "skills": [],
-            }
-
-            # Add default skill
-            default_skill_description = await llm.ask(
-                base_prompt="You are an Agent capability description summarizer. Based on the user's question, create a description of the agent's capabilities. Return only the description, do not return any other text. Call it Agent.",
-                question=f"What can this do: {summary}. tools_descriptions: {tools_descriptions}",
-                base_request=base_request,
-                outer_span=span,
-            )
-            default_examples = await llm.ask(
-                base_prompt="You are an Agent prompt example generator. Based on the user's question, create a few example prompts for how the agent can be used. Create the examples as unordered markdown list, and only return the examples.",
-                question=f"Generate examples for: {default_skill_description}.",
-                base_request=base_request,
-                outer_span=span,
-            )
-
-            default_examples = get_as_list(default_examples)
-            default_skill = {
-                "id": SERVICE_NAME.lower().replace(" ", "-"),
-                "name": SERVICE_NAME,
-                "description": get_description(default_skill_description),
-                "tags": ["default"],
-                "examples": default_examples,
-                "inputModes": ["text"],
-                "outputModes": ["text"],
-                "parameter_schema": {
-                    "type": "object",
-                    "properties": {
-                        "prompt": {
-                            "type": "string",
-                            "description": "The input prompt for the skill.",
-                        }
-                    },
-                    "required": ["prompt"],
-                },
-            }
-            agent_card["skills"].append(default_skill)
-
-            # Add skills from MCP tools
-            for index, tool in enumerate(tools):
-                tool_tags = await llm.ask(
-                    base_prompt="You are an Agent tool tag generator. Based on the tool description, generate a list of tags that are relevant to the tool. Create the examples as unordered markdown list, and only return the tags.",
-                    question=f"Generate tags for: {tool['description']}.",
+                summary = await llm.ask(
+                    base_prompt="You are an MCP concise summarization engine. Summarize the following content, suitable for a service description, giving a good overview of the different tools and capabilities. Return only the summary.",
+                    question="Summarize the following description: "
+                    + "\n".join(tools_descriptions),
                     base_request=base_request,
                     outer_span=span,
                 )
-                if "inputSchema" in tool:
-                    tool_examples = await llm.ask(
-                        base_prompt=r"You are an Agent prompt example generator. Based on the tool description and inputSchema, generate a few examples (show the example json) for how the tool can be used. If the properties are empty, just return a single example with `\{\}` Create the examples as unordered markdown list, and only return the examples.",
-                        question=f"Generate examples for: {tool['description']}\n\nInput Schema:\n```json\n{tool['inputSchema']}\n```",
-                        base_request=base_request,
-                        outer_span=span,
-                    )
-                else:
-                    tool_examples = await llm.ask(
-                        base_prompt="You are an Agent prompt example generator. Based on the tool description, generate a few example prompts for how the tool can be used. Create the examples as unordered markdown list, and only return the examples.",
-                        question=f"Generate examples for: {tool['description']}.",
-                        base_request=base_request,
-                        outer_span=span,
-                    )
-                tool_examples = get_as_list(tool_examples)
 
-                skill = {
-                    "id": tool["id"] if "id" in tool else index,
-                    "name": tool["name"],
-                    "description": tool["description"],
-                    "tags": get_as_list(tool_tags),
-                    "examples": tool_examples if tool_examples else [],
-                    "inputModes": ["data"] if "inputSchema" in tool else ["text"],
-                    "outputModes": ["data"] if "outputSchema" in tool else ["text"],
+                # Base agent card
+                agent_card = {
+                    "name": SERVICE_NAME,
+                    "description": get_description(summary),
+                    "url": f"https://{HOST}{':' + str(PORT) if PORT else ''}{MCP_BASE_PATH}/tgi/v1/a2a",
+                    "version": "1.0.0",
+                    "capabilities": {"streaming": True, "pushNotifications": False},
+                    "authentication": {"schemes": ["bearer"] if OAUTH_ENV else []},
+                    "defaultInputModes": ["data"],
+                    "defaultOutputModes": ["text", "data"],
+                    "skills": [],
                 }
-                if "inputSchema" in tool:
-                    skill["parameter_schema"] = tool["inputSchema"]
-                agent_card["skills"].append(skill)
 
-            _agent_card_cache = agent_card
+                # Add default skill
+                default_skill_description = await llm.ask(
+                    base_prompt="You are an Agent capability description summarizer. Based on the user's question, create a description of the agent's capabilities. Return only the description, do not return any other text. Call it Agent.",
+                    question=f"What can this do: {summary}. tools_descriptions: {tools_descriptions}",
+                    base_request=base_request,
+                    outer_span=span,
+                )
+                default_examples = await llm.ask(
+                    base_prompt="You are an Agent prompt example generator. Based on the user's question, create a few example prompts for how the agent can be used. Create the examples as unordered markdown list, and only return the examples.",
+                    question=f"Generate examples for: {default_skill_description}.",
+                    base_request=base_request,
+                    outer_span=span,
+                )
 
-            try:
-                _save_agent_card_to_file(agent_card)
-            except Exception:
-                pass
+                default_examples = get_as_list(default_examples)
+                default_skill = {
+                    "id": SERVICE_NAME.lower().replace(" ", "-"),
+                    "name": SERVICE_NAME,
+                    "description": get_description(default_skill_description),
+                    "tags": ["default"],
+                    "examples": default_examples,
+                    "inputModes": ["text"],
+                    "outputModes": ["text"],
+                    "parameter_schema": {
+                        "type": "object",
+                        "properties": {
+                            "prompt": {
+                                "type": "string",
+                                "description": "The input prompt for the skill.",
+                            }
+                        },
+                        "required": ["prompt"],
+                    },
+                }
+                agent_card["skills"].append(default_skill)
+
+                # Add skills from MCP tools
+                for index, tool in enumerate(tools):
+                    tool_tags = await llm.ask(
+                        base_prompt="You are an Agent tool tag generator. Based on the tool description, generate a list of tags that are relevant to the tool. Create the examples as unordered markdown list, and only return the tags.",
+                        question=f"Generate tags for: {tool['description']}.",
+                        base_request=base_request,
+                        outer_span=span,
+                    )
+                    if "inputSchema" in tool:
+                        tool_examples = await llm.ask(
+                            base_prompt=r"You are an Agent prompt example generator. Based on the tool description and inputSchema, generate a few examples (show the example json) for how the tool can be used. If the properties are empty, just return a single example with `\{\}` Create the examples as unordered markdown list, and only return the examples.",
+                            question=f"Generate examples for: {tool['description']}\n\nInput Schema:\n```json\n{tool['inputSchema']}\n```",
+                            base_request=base_request,
+                            outer_span=span,
+                        )
+                    else:
+                        tool_examples = await llm.ask(
+                            base_prompt="You are an Agent prompt example generator. Based on the tool description, generate a few example prompts for how the tool can be used. Create the examples as unordered markdown list, and only return the examples.",
+                            question=f"Generate examples for: {tool['description']}.",
+                            base_request=base_request,
+                            outer_span=span,
+                        )
+                    tool_examples = get_as_list(tool_examples)
+
+                    skill = {
+                        "id": tool["id"] if "id" in tool else index,
+                        "name": tool["name"],
+                        "description": tool["description"],
+                        "tags": get_as_list(tool_tags),
+                        "examples": tool_examples if tool_examples else [],
+                        "inputModes": ["data"] if "inputSchema" in tool else ["text"],
+                        "outputModes": ["data"] if "outputSchema" in tool else ["text"],
+                    }
+                    if "inputSchema" in tool:
+                        skill["parameter_schema"] = tool["inputSchema"]
+                    agent_card["skills"].append(skill)
+
+                _agent_card_cache = agent_card
+
+                try:
+                    _save_agent_card_to_file(agent_card)
+                except Exception:
+                    pass
+                return JSONResponse(content=agent_card)
+        finally:
             _running = False
-            return JSONResponse(content=agent_card)
 
 
 # Try to populate the in-memory cache from disk

--- a/app/well_known/agent.py
+++ b/app/well_known/agent.py
@@ -220,10 +220,7 @@ async def get_agent_card():
 
                 _agent_card_cache = agent_card
 
-                try:
-                    _save_agent_card_to_file(agent_card)
-                except Exception:
-                    pass
+                _save_agent_card_to_file(agent_card)
                 return JSONResponse(content=agent_card)
         finally:
             _running = False

--- a/app/well_known/test_agent.py
+++ b/app/well_known/test_agent.py
@@ -186,6 +186,22 @@ async def test_get_agent_card_empty_tools(
 
 
 @pytest.mark.asyncio
+async def test_get_agent_card_running_flag_reset_on_llm_failure(
+    mock_llm_client, mock_mcp_session, ensure_default_model
+):
+    """_running must be False after llm.ask throws so the next probe can retry."""
+    mock_mcp_session.set_tools(
+        [{"id": "tool1", "name": "Tool 1", "description": "Tool 1 description"}]
+    )
+    mock_llm_client.return_value.ask = AsyncMock(side_effect=RuntimeError("TGI 502"))
+
+    with pytest.raises(RuntimeError, match="TGI 502"):
+        await get_agent_card()
+
+    assert agent_module._running is False
+
+
+@pytest.mark.asyncio
 async def test_get_agent_card_tool_with_schemas(
     mock_llm_client, mock_mcp_session, ensure_default_model
 ):


### PR DESCRIPTION
Fixes #71

## What

When `llm.ask()` throws during agent card generation (e.g. TGI returning 502 from Azure OpenAI), the `_running` guard was left `True` for the lifetime of the process. Every subsequent readiness probe hit the 429 branch and the pod could never self-recover — even after the upstream failure cleared.

Wrap the generation block in `try/finally` so `_running` is always reset regardless of success or failure.

## Test

Added `test_get_agent_card_running_flag_reset_on_llm_failure` — configures `llm.ask` to raise, asserts the exception propagates, and asserts `_running` is `False` afterward.