### PR TITLE
Add inherited environment startup hook

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,6 +24,45 @@ Supports placeholders:
 MCP_SERVER_COMMAND="python server.py --data {data_path}/{user_id}"
 ```
 
+#### MCP_RUN_ON_START
+
+Command to run before the bridge starts serving traffic.
+
+- **Type:** String
+- **Default:** Not set
+- **Required:** No
+- **Example:** `npm install -g @modelcontextprotocol/server-memory`
+
+By default, this command runs in a clean environment with only `HOME` and `PATH`
+set. Use it for startup work that should not inherit runtime secrets or
+deployment-specific environment variables.
+
+```bash
+MCP_RUN_ON_START="npm install -g @modelcontextprotocol/server-memory"
+```
+
+#### MCP_RUN_ON_START_INHERIT_ENVIRONMENT
+
+Command to run before the bridge starts serving traffic while inheriting the
+current process environment.
+
+- **Type:** String
+- **Default:** Not set
+- **Required:** No
+- **Example:** `alembic upgrade head`
+
+Use this instead of `MCP_RUN_ON_START` when the startup command needs access to
+environment variables provided by the runtime. This can be useful for database
+migrations on MCP startup, where the migration command needs variables such as
+`POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.
+
+`MCP_RUN_ON_START` and `MCP_RUN_ON_START_INHERIT_ENVIRONMENT` are mutually
+exclusive. Set only one startup hook.
+
+```bash
+MCP_RUN_ON_START_INHERIT_ENVIRONMENT="alembic upgrade head"
+```
+
 #### MCP_BASE_PATH
 
 Base path for all API endpoints.

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ -n "$MCP_RUN_ON_START" ] && [ -n "$MCP_RUN_ON_START_INHERIT_ENVIRONMENT" ]; then
+  echo "MCP_RUN_ON_START and MCP_RUN_ON_START_INHERIT_ENVIRONMENT cannot both be set"
+  exit 1
+fi
+
 if [ "$#" -gt 0 ]; then
   export MCP_SERVER_COMMAND="$*"
 fi
@@ -42,6 +47,17 @@ if [ -n "$MCP_RUN_ON_START" ]; then
   rc=$?
   if [ $rc -ne 0 ]; then
     echo "MCP_RUN_ON_START command failed with exit code $rc"
+  fi
+fi
+
+# If MCP_RUN_ON_START_INHERIT_ENVIRONMENT is set, run its command before starting the server
+if [ -n "$MCP_RUN_ON_START_INHERIT_ENVIRONMENT" ]; then
+  echo "Running MCP_RUN_ON_START_INHERIT_ENVIRONMENT: $MCP_RUN_ON_START_INHERIT_ENVIRONMENT"
+  # run in the current environment and set HOME to a tmp dir so npm uses a separate cache
+  env HOME=/tmp PATH="$PATH" bash -lc "$MCP_RUN_ON_START_INHERIT_ENVIRONMENT"
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "MCP_RUN_ON_START_INHERIT_ENVIRONMENT command failed with exit code $rc"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- add a mutually exclusive inherited-environment startup hook
- document when to use MCP_RUN_ON_START versus MCP_RUN_ON_START_INHERIT_ENVIRONMENT

## Why
Some startup hooks, such as database migrations, need runtime environment variables while the existing MCP_RUN_ON_START mode intentionally runs with a clean environment.

## Validation
- bash -n start.sh