### PR TITLE
Reworked ui generation for better performance and results

### DIFF
--- a/app/app_facade/conversational_service.py
+++ b/app/app_facade/conversational_service.py
@@ -22,6 +22,12 @@ from fastapi import HTTPException
 
 from app.app_facade.env_utils import positive_int_env
 from app.app_facade.generated_schemas import generation_response_format
+from app.app_facade.patch_ops import (
+    PATCH_UPDATE_SCHEMA,
+    apply_patch_operations,
+    enforce_runtime_script_integrity,
+    legacy_patch_to_operations,
+)
 from app.app_facade.generated_types import (
     Actor,
     Scope,
@@ -34,6 +40,7 @@ from app.app_facade.prompt_helpers import (
     runtime_context_for_prompt,
     sanitize_runtime_action,
 )
+from app.app_facade.sse import assistant_status_event, sse_event
 from app.session import MCPSessionBase
 from app.tgi.models import ChatCompletionRequest, Message, MessageRole
 from app.vars import (
@@ -48,35 +55,7 @@ from app.vars import (
 
 logger = logging.getLogger("uvicorn.error")
 
-_PATCH_UPDATE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "patch": {
-            "type": "object",
-            "properties": {
-                "html": {
-                    "type": "object",
-                    "properties": {
-                        "page": {"type": "string"},
-                        "snippet": {"type": "string"},
-                    },
-                    "additionalProperties": False,
-                },
-                "service_script": {"type": "string"},
-                "components_script": {"type": "string"},
-                "test_script": {"type": "string"},
-                "dummy_data": {"type": "string"},
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": True,
-                },
-            },
-            "additionalProperties": False,
-        }
-    },
-    "required": ["patch"],
-    "additionalProperties": False,
-}
+_PATCH_UPDATE_SCHEMA = PATCH_UPDATE_SCHEMA
 
 UI_MODEL_HEADERS = {"x-inxm-model-capability": "code-generation"}
 
@@ -89,22 +68,8 @@ def _generation_response_format(schema=None, name: str = "generated_ui"):
     return generation_response_format(schema=schema, name=name)
 
 
-def _sse_event(event: str, payload: Dict[str, Any]) -> bytes:
-    return (
-        f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode(
-            "utf-8"
-        )
-    )
-
-
-def _assistant_status_event(status: str) -> bytes:
-    return _sse_event(
-        "assistant",
-        {
-            "delta": status,
-            "is_status": True,
-        },
-    )
+_sse_event = sse_event
+_assistant_status_event = assistant_status_event
 
 
 class ConversationalService:
@@ -187,6 +152,7 @@ class ConversationalService:
             ).strip().lower() in {"1", "true", "yes", "on"}
             if patch_enabled:
                 max_attempts = max(1, int(APP_UI_PATCH_RETRIES))
+                last_patch_failure: Optional[str] = None
                 for attempt_index in range(max_attempts):
                     yield _assistant_status_event(
                         f"I will try a targeted patch first (attempt {attempt_index + 1}/{max_attempts})."
@@ -201,6 +167,7 @@ class ConversationalService:
                         selected_tools=selected_tools,
                         access_token=access_token,
                         previous_metadata=session_payload.get("metadata_snapshot", {}),
+                        failure_feedback=last_patch_failure,
                     )
                     if patch_attempt:
                         candidate = patch_attempt.get("payload")
@@ -214,6 +181,9 @@ class ConversationalService:
                             # Patch was a complete no-op — didn't change scripts or HTML.
                             # Treat as failure so we fall through to full regeneration.
                             patch_reason = "patch_no_changes"
+                            last_patch_failure = (
+                                "previous patch produced no effective changes"
+                            )
                             patch_failure_reasons.append(
                                 f"attempt={attempt_index + 1}/{max_attempts}:{patch_reason}"
                             )
@@ -237,6 +207,7 @@ class ConversationalService:
                         self.service._last_patch_failure_reason
                         or "unknown_patch_failure"
                     )
+                    last_patch_failure = patch_reason
                     patch_failure_reasons.append(
                         f"attempt={attempt_index + 1}/{max_attempts}:{patch_reason}"
                     )
@@ -514,6 +485,7 @@ class ConversationalService:
         access_token: Optional[str],
         previous_metadata: Dict[str, Any],
         selected_tools: Optional[List[Dict[str, Any]]] = None,
+        failure_feedback: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         self.service._last_patch_failure_reason = None
 
@@ -535,9 +507,18 @@ class ConversationalService:
         try:
             system_prompt = (
                 "You are a UI patch planner. Return valid JSON only in this shape: "
-                '{"patch":{"html":{"page":"...","snippet":"..."},"service_script":"...","components_script":"...","test_script":"...","dummy_data":"...","metadata":{...}}}. '
-                "Only include fields that need changes. Do not include markdown fences. "
-                "When the user request involves adding, changing, or fixing tests, you MUST include test_script in the patch. "
+                '{"patch":{"operations":[{"target":"components_script","op":"replace","search":"<exact current text>","content":"<replacement>"}],"metadata":{...}}}. '
+                "Targets: service_script, components_script, test_script, dummy_data, html_page, html_snippet. "
+                "Ops: 'replace' swaps an exact 'search' string (copied VERBATIM from the current file, "
+                "unique enough to match once) with 'content'; 'append' adds 'content' at the end of the target; "
+                "'set' replaces the whole target and must only be used to create a missing file or when "
+                "nearly all of it changes. Prefer several small 'replace' operations over one big 'set'; "
+                "never re-emit unchanged code. Do not include markdown fences. "
+                "service_script and components_script are bundled into ONE module at runtime: "
+                "never add an import for an identifier that either file already imports, and never "
+                "register a pfusch component name that already exists — change existing components "
+                "with 'replace' on their current code. "
+                "When the user request involves adding, changing, or fixing tests, you MUST include operations on test_script. "
                 "Preserve component-owned data loading and partial rendering. Do not rewrite to "
                 "one root-level Promise.all() fan-out or a single full-screen blocking loader "
                 "for independent components. Keep targeted event-driven refetch behavior. "
@@ -556,6 +537,11 @@ class ConversationalService:
                     "metadata": draft_payload.get("metadata"),
                 },
             }
+            if failure_feedback:
+                payload["previous_attempt_failure"] = (
+                    f"{failure_feedback}. Fix the described problem; when a search "
+                    "string was not found, copy the exact text from the current file."
+                )
             request = ChatCompletionRequest(
                 messages=[
                     Message(role=MessageRole.SYSTEM, content=system_prompt),
@@ -587,26 +573,40 @@ class ConversationalService:
             if not isinstance(patch, dict):
                 return _fail("missing_patch_object")
 
-            candidate = copy.deepcopy(draft_payload)
-            html_patch = patch.get("html")
-            if isinstance(html_patch, dict):
-                html_target = candidate.setdefault("html", {})
-                for key in ("page", "snippet"):
-                    value = html_patch.get(key)
-                    if isinstance(value, str) and value.strip():
-                        html_target[key] = value
-
-            for key in (
-                "service_script",
-                "components_script",
-                "test_script",
-                "dummy_data",
-            ):
-                value = patch.get(key)
-                if isinstance(value, str):
-                    candidate[key] = value
+            operations = patch.get("operations")
+            if not isinstance(operations, list):
+                # Leniency: accept legacy whole-file patch objects from models
+                # that ignore the operations schema.
+                operations = legacy_patch_to_operations(patch)
 
             metadata_patch = patch.get("metadata")
+            if operations:
+                candidate, apply_errors = apply_patch_operations(
+                    draft_payload, operations
+                )
+                if candidate is None:
+                    return _fail("patch_apply_failed", "; ".join(apply_errors))
+                # service_script + components_script are bundled into one ES
+                # module, so duplicate imports / component registrations that
+                # a patch introduces are fatal at runtime. Auto-fix imports,
+                # reject duplicate registrations with actionable feedback.
+                integrity_notes, integrity_errors = enforce_runtime_script_integrity(
+                    candidate
+                )
+                if integrity_notes:
+                    logger.info(
+                        "[GeneratedUI] Patch import auto-dedup applied: %s",
+                        "; ".join(integrity_notes),
+                    )
+                if integrity_errors:
+                    return _fail(
+                        "patch_integrity_failed", "; ".join(integrity_errors)
+                    )
+            elif isinstance(metadata_patch, dict) and metadata_patch:
+                # Metadata-only patch: nothing to apply to scripts/html.
+                candidate = copy.deepcopy(draft_payload)
+            else:
+                return _fail("patch_no_operations")
             if isinstance(metadata_patch, dict):
                 current_metadata = candidate.get("metadata")
                 if not isinstance(current_metadata, dict):

--- a/app/app_facade/generated_phase1.py
+++ b/app/app_facade/generated_phase1.py
@@ -25,6 +25,10 @@ from app.app_facade.generated_schemas import (
     generation_logic_schema,
     generation_response_format,
 )
+from app.app_facade.patch_ops import (
+    detect_duplicate_component_registrations,
+    sanitize_runtime_imports,
+)
 
 
 logger = logging.getLogger("uvicorn.error")
@@ -662,19 +666,53 @@ async def run_phase1_attempt(
             current_payload["service_script"] = service_script
             current_payload["components_script"] = components_script
 
-        # TODO: remove after testing
-        logger.info(
-            "[stream_generate_ui] Phase 1 initial generation (attempt %s):\n"
-            "--- Dummy Data ---\n%s\n"
-            "--- Service Script ---\n%s\n"
-            "--- Components Script ---\n%s\n"
-            "--- Test Script ---\n%s\n",
-            attempt,
-            dummy_data or "",
-            service_script or "",
-            components_script or "",
-            test_script or "",
+        # service_script + components_script are bundled into one module;
+        # duplicate imports are a load-time SyntaxError. Auto-dedupe them,
+        # and reject duplicate component registrations.
+        sanitized_service, sanitized_components, import_notes = (
+            sanitize_runtime_imports(service_script or "", components_script or "")
         )
+        if import_notes:
+            logger.info(
+                "[stream_generate_ui] Phase 1 attempt %s deduplicated runtime imports: %s",
+                attempt,
+                "; ".join(import_notes),
+            )
+            if isinstance(service_script, str) and service_script:
+                service_script = sanitized_service
+                current_payload["service_script"] = service_script
+            components_script = sanitized_components
+            current_payload["components_script"] = components_script
+
+        duplicate_components = detect_duplicate_component_registrations(
+            f"{service_script or ''}\n{components_script or ''}"
+        )
+        if duplicate_components:
+            reason = (
+                "duplicate_component_registrations: "
+                f"{', '.join(duplicate_components)}"
+            )
+            logger.warning(
+                "[stream_generate_ui] Phase 1 attempt %s failed: %s", attempt, reason
+            )
+            messages.append(Message(role=MessageRole.ASSISTANT, content=content))
+            messages.append(
+                Message(
+                    role=MessageRole.USER,
+                    content=(
+                        "Your generated scripts register the same pfusch component "
+                        f"more than once ({', '.join(duplicate_components)}). "
+                        "Define each component exactly once and regenerate."
+                    ),
+                )
+            )
+            yield {
+                "type": "result",
+                "success": False,
+                "messages": messages,
+                "reason": reason,
+            }
+            return
 
         timeout_risks = _detect_timeout_risks(test_script, components_script)
         if timeout_risks:

--- a/app/app_facade/generated_phase1.py
+++ b/app/app_facade/generated_phase1.py
@@ -669,7 +669,7 @@ async def run_phase1_attempt(
         # service_script + components_script are bundled into one module;
         # duplicate imports are a load-time SyntaxError. Auto-dedupe them,
         # and reject duplicate component registrations.
-        sanitized_service, sanitized_components, import_notes = (
+        sanitized_service, sanitized_components, import_notes, import_conflicts = (
             sanitize_runtime_imports(service_script or "", components_script or "")
         )
         if import_notes:
@@ -683,6 +683,32 @@ async def run_phase1_attempt(
                 current_payload["service_script"] = service_script
             components_script = sanitized_components
             current_payload["components_script"] = components_script
+
+        if import_conflicts:
+            reason = f"import_conflicts: {'; '.join(import_conflicts)}"
+            logger.warning(
+                "[stream_generate_ui] Phase 1 attempt %s failed: %s", attempt, reason
+            )
+            messages.append(Message(role=MessageRole.ASSISTANT, content=content))
+            messages.append(
+                Message(
+                    role=MessageRole.USER,
+                    content=(
+                        "Your generated scripts import the same identifier from two "
+                        f"different modules ({'; '.join(import_conflicts)}). Since "
+                        "service_script and components_script are bundled into one "
+                        "module, alias one of the conflicting imports to a distinct "
+                        "local name and regenerate."
+                    ),
+                )
+            )
+            yield {
+                "type": "result",
+                "success": False,
+                "messages": messages,
+                "reason": reason,
+            }
+            return
 
         duplicate_components = detect_duplicate_component_registrations(
             f"{service_script or ''}\n{components_script or ''}"

--- a/app/app_facade/generated_service.py
+++ b/app/app_facade/generated_service.py
@@ -47,11 +47,15 @@ from app.app_facade.generated_schemas import (
 )
 from app.app_facade.env_utils import positive_int_env
 from app.app_facade.generated_storage import GeneratedUIStorage
+from app.app_facade.generation_pipeline import (
+    _DUMMY_DATA_TEST_USAGE_GUIDANCE as DUMMY_DATA_TEST_USAGE_GUIDANCE,
+)
 from app.app_facade.generated_types import (
     Actor,
     Scope,  # re-exported for route/tests import compatibility
     validate_identifier,  # noqa: F401  # re-exported for route/tests import compatibility
 )
+from app.app_facade.patch_ops import PATCH_UPDATE_SCHEMA
 from app.app_facade.test_fix_tools import _parse_tap_output, run_tool_driven_test_fix
 from app.app_facade.tool_sampling import ToolSampler
 from app.app_facade.test_runner_service import TestRunnerService
@@ -67,23 +71,6 @@ from app.app_facade.prompt_helpers import (
 
 logger = logging.getLogger("uvicorn.error")
 
-# Error codes / substrings that identify non-retryable LLM API failures.
-# When one of these appears in a phase failure reason we should stop retrying
-# immediately – hammering the API will not help and only wastes quota.
-_FATAL_LLM_ERROR_SUBSTRINGS = (
-    "insufficient_quota",
-    "invalid_api_key",
-    "authentication_error",
-    "permission_denied",
-)
-
-
-def _is_fatal_llm_error(reason: str) -> bool:
-    """Return True when *reason* indicates a non-retryable LLM API error."""
-    lower = reason.lower()
-    return any(sub in lower for sub in _FATAL_LLM_ERROR_SUBSTRINGS)
-
-
 DEFAULT_DESIGN_PROMPT = (
     "Use lightweight, responsive layouts. Prefer utility-first styling via Tailwind "
     "CSS conventions when no explicit design system guidance is provided."
@@ -91,77 +78,13 @@ DEFAULT_DESIGN_PROMPT = (
 
 UI_MODEL_HEADERS = {"x-inxm-model-capability": "code-generation"}
 
-_DUMMY_DATA_TEST_USAGE_GUIDANCE = (
-    "Dummy data module for tests is available as ./dummy_data.js. "
-    "Tests MUST import { dummyData, dummyDataSchemaHints, dummyDataGatewayHints } from './dummy_data.js' and use "
-    "svc.test.addResolved(toolName, dummyData[toolName]) for final resolved results, "
-    "or globalThis.fetch.addRoute(...) when validating raw transport/extraction paths. "
-    "If dummyDataGatewayHints?.[toolName]?.mcp_server_id exists, prefer calling "
-    "svc.call(dummyDataGatewayHints[toolName].mcp_server_id, args, ...) so gateway tools route correctly. "
-    "If dummyDataSchemaHints[toolName] exists, that tool is missing output schema; "
-    "the client should ask for schema and regenerate dummy data before relying on that fixture. "
-    "Tests MUST NOT throw or fail solely because a schema hint exists; "
-    "when hints are present, either inject explicit per-test resolved mocks for asserted fields "
-    "or assert resilient UI behavior without assuming unavailable schema fields. "
-    "Never import './dummy_data.js' in service_script/components_script; "
-    "it is test-only and not browser-delivered at runtime. "
-    "Do NOT inject fetched domain data directly via component initial state or "
-    "test-only event payloads; components must fetch/refetch themselves. "
-    "When asserting concrete field values in tests, derive expectations from a normalized shape (e.g. "
-    "const normalized = data.current_air_quality || data; const pm25 = normalized.pm2_5) instead of assuming flat paths. "
-    "Do NOT hardcode dynamic time/value literals when fixture payload already provides source-of-truth fields; "
-    "assert against transformed fixture values."
-)
-_PATCH_UPDATE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "patch": {
-            "type": "object",
-            "properties": {
-                "html": {
-                    "type": "object",
-                    "properties": {
-                        "page": {"type": "string"},
-                        "snippet": {"type": "string"},
-                    },
-                    "additionalProperties": False,
-                },
-                "service_script": {"type": "string"},
-                "components_script": {"type": "string"},
-                "test_script": {"type": "string"},
-                "dummy_data": {"type": "string"},
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": True,
-                },
-            },
-            "additionalProperties": False,
-        }
-    },
-    "required": ["patch"],
-    "additionalProperties": False,
-}
+# Canonical definitions live in generation_pipeline / patch_ops; re-exported
+# here for import compatibility.
+_DUMMY_DATA_TEST_USAGE_GUIDANCE = DUMMY_DATA_TEST_USAGE_GUIDANCE
+_PATCH_UPDATE_SCHEMA = PATCH_UPDATE_SCHEMA
 
 
 NODE_TEST_TIMEOUT_MS = positive_int_env("GENERATED_UI_NODE_TEST_TIMEOUT_MS", 8000)
-
-
-def _sse_event(event: str, payload: Dict[str, Any]) -> bytes:
-    return (
-        f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode(
-            "utf-8"
-        )
-    )
-
-
-def _assistant_status_event(status: str) -> bytes:
-    return _sse_event(
-        "assistant",
-        {
-            "delta": status,
-            "is_status": True,
-        },
-    )
 
 
 def _load_pfusch_prompt() -> str:

--- a/app/app_facade/generation_pipeline.py
+++ b/app/app_facade/generation_pipeline.py
@@ -90,6 +90,12 @@ _PHASE1_CONTRACT_MESSAGE = (
     "service_script (optional). Do NOT return template_parts, html, or metadata."
 )
 
+# How many characters of each retained failure reason to carry into the next
+# retry's messages (see the retry-feedback loop in
+# ``_stream_generate_and_persist``), and how many recent reasons to keep.
+_PHASE1_RETRY_FEEDBACK_REASON_CHARS = 400
+_PHASE1_RETRY_FEEDBACK_MAX_REASONS = 2
+
 # Substrings that identify non-retryable LLM failures: retrying will not help
 # (context overflow) or only wastes quota (auth / quota errors).
 _FATAL_LLM_ERROR_MARKERS = (
@@ -539,7 +545,10 @@ class GenerationPipeline:
                 attempt_messages = copy.deepcopy(messages)
                 if phase1_failure_reasons:
                     recent = " | ".join(
-                        reason[:400] for reason in phase1_failure_reasons[-2:]
+                        reason[:_PHASE1_RETRY_FEEDBACK_REASON_CHARS]
+                        for reason in phase1_failure_reasons[
+                            -_PHASE1_RETRY_FEEDBACK_MAX_REASONS:
+                        ]
                     )
                     attempt_messages.append(
                         Message(

--- a/app/app_facade/generation_pipeline.py
+++ b/app/app_facade/generation_pipeline.py
@@ -3,6 +3,10 @@
 The ``GenerationPipeline`` class owns the full UI generation and update
 lifecycle, including phased attempts, dummy-data augmentation, and
 test orchestration during generation.
+
+``stream_generate_ui`` (create) and ``stream_update_ui`` (update) share a
+single implementation, ``_stream_generate_and_persist``; the public
+methods only differ in their preconditions and how the record is persisted.
 """
 
 import copy
@@ -30,6 +34,8 @@ from app.app_facade.generated_types import (
     Actor,
     Scope,
 )
+from app.app_facade.patch_ops import enforce_runtime_script_integrity
+from app.app_facade.sse import sse_event
 from app.app_facade.prompt_helpers import (
     parse_json,
     runtime_context_for_prompt,
@@ -78,33 +84,34 @@ _DUMMY_DATA_TEST_USAGE_GUIDANCE = (
     "assert against transformed fixture values."
 )
 
+_PHASE1_CONTRACT_MESSAGE = (
+    "PHASE 1 CONTRACT (STRICT): Return ONLY a JSON object for logic generation "
+    "with keys: components_script (required), test_script (required), "
+    "service_script (optional). Do NOT return template_parts, html, or metadata."
+)
+
+# Substrings that identify non-retryable LLM failures: retrying will not help
+# (context overflow) or only wastes quota (auth / quota errors).
+_FATAL_LLM_ERROR_MARKERS = (
+    "maximum context length",
+    "context window",
+    "insufficient_quota",
+    "invalid_api_key",
+    "authentication_error",
+    "permission_denied",
+)
+
 
 def _generation_response_format(schema=None, name: str = "generated_ui"):
     return generation_response_format(schema=schema, name=name)
 
 
 def _is_fatal_llm_error(text: str) -> bool:
-    return any(
-        marker in text for marker in ("maximum context length", "context window")
-    )
+    lower = (text or "").lower()
+    return any(marker in lower for marker in _FATAL_LLM_ERROR_MARKERS)
 
 
-def _sse_event(event: str, payload: Dict[str, Any]) -> bytes:
-    return (
-        f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode(
-            "utf-8"
-        )
-    )
-
-
-def _assistant_status_event(status: str) -> bytes:
-    return _sse_event(
-        "assistant",
-        {
-            "delta": status,
-            "is_status": True,
-        },
-    )
+_sse_event = sse_event
 
 
 class GenerationPipeline:
@@ -154,19 +161,6 @@ class GenerationPipeline:
             tools=list(tools or []),
             access_token=access_token,
             previous=None,
-        )
-
-        # TODO: remove after testing
-        logger.info(
-            "[create_ui] Initial generation starting point:\n"
-            "--- Dummy Data ---\n%s\n"
-            "--- Service Script ---\n%s\n"
-            "--- Components Script ---\n%s\n"
-            "--- Test Script ---\n%s\n",
-            generated.get("dummy_data", ""),
-            generated.get("service_script", ""),
-            generated.get("components_script", ""),
-            generated.get("test_script", ""),
         )
 
         timestamp = self.service._now()
@@ -250,6 +244,84 @@ class GenerationPipeline:
         ):
             yield item
 
+    def _reusable_dummy_data(
+        self,
+        *,
+        previous: Optional[Dict[str, Any]],
+        allowed_tools: Optional[List[Dict[str, Any]]],
+        runtime_context: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Return the previous dummy-data module when it already covers all
+        selected tools, so updates skip the sampling + LLM fixture pipeline.
+
+        Fresh runtime observations disable reuse: they usually exist because
+        real payload shapes diverged from the fixtures.
+        """
+        if not previous:
+            return None
+        if runtime_context_for_prompt(runtime_context):
+            return None
+        candidate = (previous.get("current") or {}).get("dummy_data")
+        if not isinstance(candidate, str) or not candidate.strip():
+            return None
+        if not self.service.tool_sampler.dummy_data_covers_tools(
+            candidate, allowed_tools
+        ):
+            return None
+        return candidate
+
+    async def _prepare_dummy_data(
+        self,
+        *,
+        session: MCPSessionBase,
+        scope: Scope,
+        ui_id: str,
+        name: str,
+        prompt: str,
+        allowed_tools: Optional[List[Dict[str, Any]]],
+        access_token: Optional[str],
+        previous: Optional[Dict[str, Any]] = None,
+        runtime_context: Optional[Dict[str, Any]] = None,
+    ) -> tuple:
+        """Generate (or reuse) the dummy-data module and augment tools with
+        derived output schemas. Returns ``(dummy_data, allowed_tools, reused)``."""
+        reusable = self._reusable_dummy_data(
+            previous=previous,
+            allowed_tools=allowed_tools,
+            runtime_context=runtime_context,
+        )
+        if reusable is not None:
+            logger.info(
+                "[GenerationPipeline] Reusing existing dummy data module for %s/%s (covers all selected tools)",
+                ui_id,
+                name,
+            )
+            dummy_data = reusable
+        else:
+            dummy_data = await self.service.tool_sampler._generate_dummy_data(
+                session=session,
+                scope=scope,
+                ui_id=ui_id,
+                name=name,
+                prompt=prompt,
+                allowed_tools=allowed_tools,
+                access_token=access_token,
+                runtime_context=runtime_context,
+            )
+
+        allowed_tools, derived_schema_count = (
+            await self.service.tool_sampler._augment_tools_with_derived_output_schemas(
+                allowed_tools=allowed_tools,
+                dummy_data_module=dummy_data,
+            )
+        )
+        if derived_schema_count:
+            logger.info(
+                "[GenerationPipeline] Added %s derived output schemas from dummy data to allowed tools",
+                derived_schema_count,
+            )
+        return dummy_data, allowed_tools, reusable is not None
+
     async def stream_generate_ui(
         self,
         *,
@@ -262,49 +334,109 @@ class GenerationPipeline:
         tools: Optional[Iterable[str]],
         access_token: Optional[str],
     ) -> AsyncIterator[bytes]:
-        """
-        Stream UI generation as Server-Sent Events (SSE).
-
-        Yields bytes that are already formatted as SSE messages. The stream
-        will emit keepalive comments roughly every 10 seconds during idle
-        model streaming to avoid client timeouts.
-        """
+        """Stream UI creation as Server-Sent Events (SSE)."""
         logger.info(
             f"[stream_generate_ui] Starting stream for ui_id={ui_id}, name={name}, scope={scope.kind}:{scope.identifier}"
         )
-        requested_tools = list(tools or [])
-
-        # Basic existence and permission checks similar to create_ui
         if self.storage.exists(scope, ui_id, name):
             logger.warning(f"[stream_generate_ui] UI already exists: {ui_id}/{name}")
-            # SSE error message and stop
-            payload = json.dumps({"error": "Ui already exists for this id and name"})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
+            yield _sse_event("error", {"error": "Ui already exists for this id and name"})
             return
 
         if scope.kind == "user" and actor.user_id != scope.identifier:
             logger.warning(
                 f"[stream_generate_ui] Permission denied: user {actor.user_id} cannot create UI for user {scope.identifier}"
             )
-            payload = json.dumps(
-                {"error": "User uis may only be created by the owning user"}
+            yield _sse_event(
+                "error", {"error": "User uis may only be created by the owning user"}
             )
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
             return
 
         if scope.kind == "group" and scope.identifier not in set(actor.groups or []):
             logger.warning(
                 f"[stream_generate_ui] Permission denied: user {actor.user_id} not in group {scope.identifier}"
             )
-            payload = json.dumps(
-                {"error": "Group uis may only be created by group members"}
+            yield _sse_event(
+                "error", {"error": "Group uis may only be created by group members"}
             )
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
             return
 
-        # Wrap initialization in try-catch to ensure we yield error messages
-        # if anything fails before streaming starts
-        logger.info("[stream_generate_ui] Building system prompt and selecting tools")
+        async for chunk in self._stream_generate_and_persist(
+            session=session,
+            scope=scope,
+            actor=actor,
+            ui_id=ui_id,
+            name=name,
+            prompt=prompt,
+            tools=tools,
+            access_token=access_token,
+            existing=None,
+        ):
+            yield chunk
+
+    async def stream_update_ui(
+        self,
+        *,
+        session: MCPSessionBase,
+        scope: Scope,
+        actor: Actor,
+        ui_id: str,
+        name: str,
+        prompt: str,
+        tools: Optional[Iterable[str]],
+        access_token: Optional[str],
+    ) -> AsyncIterator[bytes]:
+        """Stream UI updates as SSE, using the same pipeline as create."""
+        logger.info(
+            f"[stream_update_ui] Starting stream for ui_id={ui_id}, name={name}, scope={scope.kind}:{scope.identifier}"
+        )
+        try:
+            existing = self.storage.read(scope, ui_id, name)
+        except FileNotFoundError:
+            logger.warning(f"[stream_update_ui] UI not found: {ui_id}/{name}")
+            yield _sse_event("error", {"error": "Ui not found"})
+            return
+
+        try:
+            self.service._assert_scope_consistency(existing, scope, name)
+            self.service._ensure_update_permissions(existing, scope, actor)
+        except HTTPException as exc:
+            yield _sse_event("error", {"error": exc.detail})
+            yield _sse_event("log", {"message": "Page creation failed"})
+            return
+
+        async for chunk in self._stream_generate_and_persist(
+            session=session,
+            scope=scope,
+            actor=actor,
+            ui_id=ui_id,
+            name=name,
+            prompt=prompt,
+            tools=tools,
+            access_token=access_token,
+            existing=existing,
+        ):
+            yield chunk
+
+    async def _stream_generate_and_persist(
+        self,
+        *,
+        session: MCPSessionBase,
+        scope: Scope,
+        actor: Actor,
+        ui_id: str,
+        name: str,
+        prompt: str,
+        tools: Optional[Iterable[str]],
+        access_token: Optional[str],
+        existing: Optional[Dict[str, Any]],
+    ) -> AsyncIterator[bytes]:
+        """Shared streaming implementation for create (``existing is None``)
+        and update flows: phase 1 (logic + tests, with retries), phase 2
+        (presentation), persistence, final ``done`` event."""
+        mode = "update" if existing is not None else "create"
+        log_tag = f"[stream_{'update' if existing is not None else 'generate'}_ui]"
+        requested_tools = list(tools or [])
 
         attempt = 0
         max_attempts = 3
@@ -318,15 +450,18 @@ class GenerationPipeline:
 
         try:
             system_prompt = await self.service._build_system_prompt(session)
-            logger.info(
-                f"[stream_generate_ui] System prompt built, length={len(system_prompt)}"
-            )
+            logger.info(f"{log_tag} System prompt built, length={len(system_prompt)}")
 
             allowed_tools = await self.service._select_tools(
                 session, requested_tools, prompt
             )
+            allowed_tools = cap_tools_for_prompt(
+                allowed_tools,
+                max_tools=GENERATED_UI_MAX_TOOLS,
+                max_bytes=GENERATED_UI_MAX_TOOLS_BYTES,
+            )
 
-            message_payload = {
+            message_payload: Dict[str, Any] = {
                 "ui": {
                     "id": ui_id,
                     "name": name,
@@ -338,22 +473,36 @@ class GenerationPipeline:
                     "requested_tools": requested_tools,
                 },
             }
-
-            initial_message = Message(
-                role=MessageRole.USER,
-                content=json.dumps(message_payload, ensure_ascii=False),
+            if existing is not None:
+                previous_metadata = existing.get("metadata", {})
+                message_payload["context"] = {
+                    "original_prompt": self.service._initial_prompt(previous_metadata),
+                    "history": history_for_prompt(
+                        previous_metadata.get("history", []),
+                        max_entries=GENERATED_UI_MAX_HISTORY_ENTRIES,
+                        max_bytes=GENERATED_UI_MAX_HISTORY_BYTES,
+                    ),
+                    "current_state": context_state_for_prompt(
+                        existing.get("current", {}),
+                        max_bytes=max(2048, GENERATED_UI_MAX_HISTORY_BYTES // 2),
+                    ),
+                }
+            message_payload, _prompt_compaction = cap_message_payload_for_prompt(
+                message_payload,
+                max_bytes=GENERATED_UI_MAX_MESSAGE_PAYLOAD_BYTES,
             )
 
             messages = [
                 Message(role=MessageRole.SYSTEM, content=system_prompt),
-                initial_message,
+                Message(
+                    role=MessageRole.USER,
+                    content=json.dumps(message_payload, ensure_ascii=False),
+                ),
             ]
 
-            yield f"event: log\ndata: {json.dumps({'message': 'Generating dummy data for tests...'})}\n\n".encode(
-                "utf-8"
-            )
+            yield _sse_event("log", {"message": "Generating dummy data for tests..."})
 
-            dummy_data = await self.service.tool_sampler._generate_dummy_data(
+            dummy_data, allowed_tools, dummy_reused = await self._prepare_dummy_data(
                 session=session,
                 scope=scope,
                 ui_id=ui_id,
@@ -361,18 +510,11 @@ class GenerationPipeline:
                 prompt=prompt,
                 allowed_tools=allowed_tools,
                 access_token=access_token,
+                previous=existing,
             )
-
-            allowed_tools, derived_schema_count = (
-                await self.service.tool_sampler._augment_tools_with_derived_output_schemas(
-                    allowed_tools=allowed_tools,
-                    dummy_data_module=dummy_data,
-                )
-            )
-            if derived_schema_count:
-                logger.info(
-                    "[stream_generate_ui] Added %s derived output schemas from dummy data to allowed tools",
-                    derived_schema_count,
+            if dummy_reused:
+                yield _sse_event(
+                    "log", {"message": "Reusing existing test fixtures (unchanged tools)"}
                 )
 
             messages.append(
@@ -385,22 +527,29 @@ class GenerationPipeline:
                 )
             )
             messages.append(
-                Message(
-                    role=MessageRole.USER,
-                    content=(
-                        "PHASE 1 CONTRACT (STRICT): Return ONLY a JSON object for logic generation "
-                        "with keys: components_script (required), test_script (required), "
-                        "service_script (optional). Do NOT return template_parts, html, or metadata."
-                    ),
-                )
+                Message(role=MessageRole.USER, content=_PHASE1_CONTRACT_MESSAGE)
             )
 
             # --- PHASE 1: GENERATE LOGIC AND TESTS ---
             phase1_success = False
             while attempt < max_attempts:
                 attempt += 1
-                # Clone messages for this attempt to avoid polluting history on retry
+                # Clone messages for this attempt so failed-attempt history is
+                # discarded; only a compact failure summary carries over.
                 attempt_messages = copy.deepcopy(messages)
+                if phase1_failure_reasons:
+                    recent = " | ".join(
+                        reason[:400] for reason in phase1_failure_reasons[-2:]
+                    )
+                    attempt_messages.append(
+                        Message(
+                            role=MessageRole.USER,
+                            content=(
+                                f"Previous generation attempt(s) failed: {recent}. "
+                                "Generate a corrected payload that avoids these failure modes."
+                            ),
+                        )
+                    )
 
                 async for item in self._phase_1_attempt(
                     attempt=attempt,
@@ -416,7 +565,7 @@ class GenerationPipeline:
                         if item["success"]:
                             phase1_success = True
                             logic_payload = item["payload"]
-                            # Update main messages with the successful history
+                            # Keep the successful attempt history
                             messages = item["messages"]
                         else:
                             reason = (
@@ -424,32 +573,30 @@ class GenerationPipeline:
                                 or item.get("error")
                                 or "unknown phase 1 failure"
                             )
-                            phase1_failure_reasons.append(
-                                f"attempt {attempt}: {reason}"
-                            )
+                            phase1_failure_reasons.append(f"attempt {attempt}: {reason}")
                             logger.warning(
-                                "[stream_generate_ui] Phase 1 attempt %s failed: %s",
+                                "%s Phase 1 attempt %s failed: %s",
+                                log_tag,
                                 attempt,
                                 reason,
                             )
-                            yield f"event: log\ndata: {json.dumps({'message': f'Phase 1 attempt {attempt} failed', 'reason': reason})}\n\n".encode(
-                                "utf-8"
+                            yield _sse_event(
+                                "log",
+                                {
+                                    "message": f"Phase 1 attempt {attempt} failed",
+                                    "reason": reason,
+                                },
                             )
                             if _is_fatal_llm_error(reason):
-                                # Non-retryable error (quota exceeded, invalid auth, etc.).
-                                # Stop immediately – retrying will not help and only wastes quota.
+                                # Non-retryable error (context overflow, quota
+                                # exceeded, invalid auth). Retrying will not help.
                                 logger.error(
-                                    "[stream_generate_ui] Fatal LLM error on attempt %s, aborting retries: %s",
+                                    "%s Fatal LLM error on attempt %s, aborting retries: %s",
+                                    log_tag,
                                     attempt,
                                     reason,
                                 )
                                 phase1_fatal_error = True
-                            # Should we update messages here?
-                            # If we update messages here, we are keeping failed attempt history, which defeats "discarding".
-                            # The user requested "cleanly discarded once an attempt completed".
-                            # So we DO NOT update `messages` on failure.
-                            # The next attempt will start from original `messages` state (fresh retry).
-                            pass
                         break
 
                 if phase1_success or phase1_fatal_error:
@@ -460,7 +607,8 @@ class GenerationPipeline:
                     " | ".join(phase1_failure_reasons) if phase1_failure_reasons else ""
                 )
                 logger.error(
-                    "[stream_generate_ui] Failed to generate valid logic after %s attempts. Reasons: %s",
+                    "%s Failed to generate valid logic after %s attempts. Reasons: %s",
+                    log_tag,
                     max_attempts,
                     detail or "none captured",
                 )
@@ -469,15 +617,15 @@ class GenerationPipeline:
                 )
                 if detail:
                     error_message = f"{error_message}: {detail}"
-                yield f"event: error\ndata: {json.dumps({'error': error_message})}\n\n".encode(
-                    "utf-8"
-                )
+                yield _sse_event("error", {"error": error_message})
                 return
 
             # --- PHASE 2: GENERATE PRESENTATION ---
             presentation_payload: Dict[str, Any] = {}
             instruction = (
-                "Tests passed. Now generate presentation template parts only. "
+                "Tests passed. Now "
+                + ("update" if existing is not None else "generate")
+                + " presentation template parts only. "
                 "Return `template_parts` and `metadata`. "
                 "Do not return `html.page` or `html.snippet`."
             )
@@ -504,409 +652,117 @@ class GenerationPipeline:
             # Merge
             payload_obj = {**logic_payload, **presentation_payload}
             self.service._normalise_payload(
-                payload_obj, scope, ui_id, name, prompt, None
-            )
-
-        except HTTPException as exc:
-            logger.error(
-                f"[stream_generate_ui] HTTPException during initialization: {exc.detail}",
-                exc_info=exc,
-            )
-            payload = json.dumps({"error": exc.detail})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
-            return
-        except Exception as exc:
-            logger.error(
-                f"[stream_generate_ui] Exception during initialization: {str(exc)}",
-                exc_info=exc,
-            )
-            payload = json.dumps({"error": "Failed to initialize generation"})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
-            return
-
-        # Build final record and persist
-        logger.info("[stream_generate_ui] Building final record")
-        timestamp = self.service._now()
-        payload_scripts = changed_scripts(payload_obj, None)
-        record = {
-            "metadata": {
-                "id": ui_id,
-                "name": name,
-                "scope": {"type": scope.kind, "id": scope.identifier},
-                "owner": {"type": scope.kind, "id": scope.identifier},
-                "created_by": actor.user_id,
-                "created_at": timestamp,
-                "updated_at": timestamp,
-                "version": 1,
-                "published_at": timestamp,
-                "published_by": actor.user_id,
-                "history": [
-                    history_entry(
-                        action="create",
-                        prompt=prompt,
-                        tools=list(tools or []),
-                        user_id=actor.user_id,
-                        generated_at=timestamp,
-                        payload_metadata=payload_obj.get("metadata", {}),
-                        payload_html=payload_obj.get("html", {}),
-                        payload_scripts=payload_scripts or None,
-                    )
-                ],
-            },
-            "current": payload_obj,
-        }
-
-        # persist
-        logger.info("[stream_generate_ui] Persisting record to storage")
-        try:
-            self.storage.write(scope, ui_id, name, record)
-            logger.info("[stream_generate_ui] Record persisted successfully")
-        except Exception as e:
-            logger.error(
-                f"[stream_generate_ui] Failed to persist record: {str(e)}", exc_info=e
-            )
-            payload = json.dumps({"error": f"Failed to persist generated ui: {str(e)}"})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
-            return
-
-        # Final event with the created record
-        logger.info("[stream_generate_ui] Sending final done event")
-
-        # We want to send the expanded record to the client so they can run it
-        expanded_record = record.copy()
-        expanded_record["current"] = self.service._expand_payload(record["current"])
-
-        final_payload = json.dumps(
-            {"status": "created", "record": expanded_record}, ensure_ascii=False
-        )
-        yield f"event: log\ndata: {json.dumps({'message': 'Page successfully generated'})}\n\n".encode(
-            "utf-8"
-        )
-        yield f"event: done\ndata: {final_payload}\n\n".encode("utf-8")
-        # Send proper SSE done marker
-        yield b"data: [DONE]\n\n"
-        logger.info("[stream_generate_ui] Stream completed successfully")
-
-    async def stream_update_ui(
-        self,
-        *,
-        session: MCPSessionBase,
-        scope: Scope,
-        actor: Actor,
-        ui_id: str,
-        name: str,
-        prompt: str,
-        tools: Optional[Iterable[str]],
-        access_token: Optional[str],
-    ) -> AsyncIterator[bytes]:
-        """
-        Stream UI updates as Server-Sent Events (SSE).
-
-        Uses the same generation/test pipeline as create, but applies the
-        results to an existing UI record with update history.
-        """
-        logger.info(
-            f"[stream_update_ui] Starting stream for ui_id={ui_id}, name={name}, scope={scope.kind}:{scope.identifier}"
-        )
-        requested_tools = list(tools or [])
-
-        try:
-            existing = self.storage.read(scope, ui_id, name)
-        except FileNotFoundError:
-            logger.warning(f"[stream_update_ui] UI not found: {ui_id}/{name}")
-            payload = json.dumps({"error": "Ui not found"})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            return
-
-        try:
-            self.service._assert_scope_consistency(existing, scope, name)
-            self.service._ensure_update_permissions(existing, scope, actor)
-        except HTTPException as exc:
-            payload = json.dumps({"error": exc.detail})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
-            return
-
-        attempt = 0
-        max_attempts = 3
-        messages: List[Message] = []
-        allowed_tools: List[Dict[str, Any]] = []
-        payload_obj: Dict[str, Any] = {}
-        logic_payload: Dict[str, Any] = {}
-        dummy_data: Optional[str] = None
-        phase1_failure_reasons: List[str] = []
-        phase1_fatal_error: bool = False
-
-        try:
-            system_prompt = await self.service._build_system_prompt(session)
-            logger.info(
-                f"[stream_update_ui] System prompt built, length={len(system_prompt)}"
-            )
-
-            allowed_tools = await self.service._select_tools(
-                session, requested_tools, prompt
-            )
-
-            previous_metadata = existing.get("metadata", {})
-            message_payload = {
-                "ui": {
-                    "id": ui_id,
-                    "name": name,
-                    "scope": {"type": scope.kind, "id": scope.identifier},
-                },
-                "request": {
-                    "prompt": prompt,
-                    "tools": [t["function"]["name"] for t in (allowed_tools or [])],
-                    "requested_tools": requested_tools,
-                },
-                "context": {
-                    "original_prompt": self.service._initial_prompt(previous_metadata),
-                    "history": history_for_prompt(previous_metadata.get("history", [])),
-                    "current_state": context_state_for_prompt(
-                        existing.get("current", {})
-                    ),
-                },
-            }
-
-            initial_message = Message(
-                role=MessageRole.USER,
-                content=json.dumps(message_payload, ensure_ascii=False),
-            )
-
-            messages = [
-                Message(role=MessageRole.SYSTEM, content=system_prompt),
-                initial_message,
-            ]
-
-            yield f"event: log\ndata: {json.dumps({'message': 'Generating dummy data for tests...'})}\n\n".encode(
-                "utf-8"
-            )
-
-            dummy_data = await self.service.tool_sampler._generate_dummy_data(
-                session=session,
-                scope=scope,
-                ui_id=ui_id,
-                name=name,
-                prompt=prompt,
-                allowed_tools=allowed_tools,
-                access_token=access_token,
-            )
-
-            messages.append(
-                Message(
-                    role=MessageRole.USER,
-                    content=(
-                        f"{_DUMMY_DATA_TEST_USAGE_GUIDANCE} "
-                        f"Tools: {[t['function']['name'] for t in (allowed_tools or [])]}"
-                    ),
-                )
-            )
-            messages.append(
-                Message(
-                    role=MessageRole.USER,
-                    content=(
-                        "PHASE 1 CONTRACT (STRICT): Return ONLY a JSON object for logic generation "
-                        "with keys: components_script (required), test_script (required), "
-                        "service_script (optional). Do NOT return template_parts, html, or metadata."
-                    ),
-                )
-            )
-
-            # --- PHASE 1: GENERATE LOGIC AND TESTS ---
-            phase1_success = False
-            while attempt < max_attempts:
-                attempt += 1
-                attempt_messages = copy.deepcopy(messages)
-
-                async for item in self._phase_1_attempt(
-                    attempt=attempt,
-                    max_attempts=max_attempts,
-                    messages=attempt_messages,
-                    allowed_tools=allowed_tools,
-                    dummy_data=dummy_data,
-                    access_token=access_token,
-                ):
-                    if isinstance(item, bytes):
-                        yield item
-                    elif isinstance(item, dict) and item.get("type") == "result":
-                        if item["success"]:
-                            phase1_success = True
-                            logic_payload = item["payload"]
-                            messages = item["messages"]
-                        else:
-                            reason = (
-                                item.get("reason")
-                                or item.get("error")
-                                or "unknown phase 1 failure"
-                            )
-                            phase1_failure_reasons.append(
-                                f"attempt {attempt}: {reason}"
-                            )
-                            logger.warning(
-                                "[stream_update_ui] Phase 1 attempt %s failed: %s",
-                                attempt,
-                                reason,
-                            )
-                            yield f"event: log\ndata: {json.dumps({'message': f'Phase 1 attempt {attempt} failed', 'reason': reason})}\n\n".encode(
-                                "utf-8"
-                            )
-                            if _is_fatal_llm_error(reason):
-                                # Non-retryable error (quota exceeded, invalid auth, etc.).
-                                # Stop immediately – retrying will not help and only wastes quota.
-                                logger.error(
-                                    "[stream_update_ui] Fatal LLM error on attempt %s, aborting retries: %s",
-                                    attempt,
-                                    reason,
-                                )
-                                phase1_fatal_error = True
-                        break
-
-                if phase1_success or phase1_fatal_error:
-                    break
-
-            if not phase1_success:
-                detail = (
-                    " | ".join(phase1_failure_reasons) if phase1_failure_reasons else ""
-                )
-                logger.error(
-                    "[stream_update_ui] Failed to generate valid logic after %s attempts. Reasons: %s",
-                    max_attempts,
-                    detail or "none captured",
-                )
-                error_message = (
-                    f"Failed to generate valid logic after {max_attempts} attempts"
-                )
-                if detail:
-                    error_message = f"{error_message}: {detail}"
-                yield f"event: error\ndata: {json.dumps({'error': error_message})}\n\n".encode(
-                    "utf-8"
-                )
-                return
-
-            # --- PHASE 2: GENERATE PRESENTATION ---
-            presentation_payload: Dict[str, Any] = {}
-            instruction = (
-                "Tests passed. Now update presentation template parts only. "
-                "Return `template_parts` and `metadata`. "
-                "Do not return `html.page` or `html.snippet`."
-            )
-
-            phase2_system_prompt = await self.service._build_phase2_system_prompt(
-                session
-            )
-
-            async for item in self._phase_2_attempt(
-                system_prompt=phase2_system_prompt,
-                prompt=prompt,
-                logic_payload=logic_payload,
-                access_token=access_token,
-                instruction=instruction,
-            ):
-                if isinstance(item, bytes):
-                    yield item
-                elif isinstance(item, dict) and item.get("type") == "result":
-                    if item["success"]:
-                        presentation_payload = item["payload"]
-                    else:
-                        return
-
-            payload_obj = {**logic_payload, **presentation_payload}
-            self.service._normalise_payload(
                 payload_obj, scope, ui_id, name, prompt, existing
             )
 
         except HTTPException as exc:
             logger.error(
-                f"[stream_update_ui] HTTPException during update: {exc.detail}",
+                f"{log_tag} HTTPException during {mode}: {exc.detail}",
                 exc_info=exc,
             )
-            payload = json.dumps({"error": exc.detail})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
+            yield _sse_event("error", {"error": exc.detail})
+            yield _sse_event("log", {"message": "Page creation failed"})
             return
         except Exception as exc:
             logger.error(
-                f"[stream_update_ui] Exception during update: {str(exc)}",
+                f"{log_tag} Exception during {mode}: {str(exc)}",
                 exc_info=exc,
             )
-            payload = json.dumps({"error": "Failed to update ui"})
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
+            fallback = (
+                "Failed to update ui"
+                if existing is not None
+                else "Failed to initialize generation"
             )
+            yield _sse_event("error", {"error": fallback})
+            yield _sse_event("log", {"message": "Page creation failed"})
             return
 
         # Build final record and persist
-        logger.info("[stream_update_ui] Building updated record")
+        logger.info(f"{log_tag} Building final record")
         timestamp = self.service._now()
-        existing.setdefault("metadata", {})
-        metadata = existing["metadata"]
-        self.service._ensure_version_metadata(metadata)
-        metadata["updated_at"] = timestamp
-        metadata["updated_by"] = actor.user_id
-        metadata["version"] = self.service._current_version(metadata) + 1
-        metadata["published_at"] = timestamp
-        metadata["published_by"] = actor.user_id
-        history = metadata.setdefault("history", [])
-        payload_scripts = changed_scripts(payload_obj, existing.get("current", {}))
-        history.append(
-            history_entry(
-                action="update",
-                prompt=prompt,
-                tools=list(tools or []),
-                user_id=actor.user_id,
-                generated_at=timestamp,
-                payload_metadata=payload_obj.get("metadata", {}),
-                payload_html=payload_obj.get("html", {}),
-                payload_scripts=payload_scripts or None,
+        if existing is None:
+            payload_scripts = changed_scripts(payload_obj, None)
+            record = {
+                "metadata": {
+                    "id": ui_id,
+                    "name": name,
+                    "scope": {"type": scope.kind, "id": scope.identifier},
+                    "owner": {"type": scope.kind, "id": scope.identifier},
+                    "created_by": actor.user_id,
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "version": 1,
+                    "published_at": timestamp,
+                    "published_by": actor.user_id,
+                    "history": [
+                        history_entry(
+                            action="create",
+                            prompt=prompt,
+                            tools=list(tools or []),
+                            user_id=actor.user_id,
+                            generated_at=timestamp,
+                            payload_metadata=payload_obj.get("metadata", {}),
+                            payload_html=payload_obj.get("html", {}),
+                            payload_scripts=payload_scripts or None,
+                        )
+                    ],
+                },
+                "current": payload_obj,
+            }
+        else:
+            existing.setdefault("metadata", {})
+            metadata = existing["metadata"]
+            self.service._ensure_version_metadata(metadata)
+            metadata["updated_at"] = timestamp
+            metadata["updated_by"] = actor.user_id
+            metadata["version"] = self.service._current_version(metadata) + 1
+            metadata["published_at"] = timestamp
+            metadata["published_by"] = actor.user_id
+            history = metadata.setdefault("history", [])
+            payload_scripts = changed_scripts(payload_obj, existing.get("current", {}))
+            history.append(
+                history_entry(
+                    action="update",
+                    prompt=prompt,
+                    tools=list(tools or []),
+                    user_id=actor.user_id,
+                    generated_at=timestamp,
+                    payload_metadata=payload_obj.get("metadata", {}),
+                    payload_html=payload_obj.get("html", {}),
+                    payload_scripts=payload_scripts or None,
+                )
             )
-        )
+            existing["current"] = payload_obj
+            record = existing
 
-        existing["current"] = payload_obj
-
-        logger.info("[stream_update_ui] Persisting record to storage")
+        logger.info(f"{log_tag} Persisting record to storage")
         try:
-            self.storage.write(scope, ui_id, name, existing)
-            logger.info("[stream_update_ui] Record persisted successfully")
+            self.storage.write(scope, ui_id, name, record)
+            logger.info(f"{log_tag} Record persisted successfully")
         except Exception as exc:
             logger.error(
-                f"[stream_update_ui] Failed to persist record: {str(exc)}",
-                exc_info=exc,
+                f"{log_tag} Failed to persist record: {str(exc)}", exc_info=exc
             )
-            payload = json.dumps(
-                {"error": f"Failed to persist generated ui: {str(exc)}"}
+            yield _sse_event(
+                "error", {"error": f"Failed to persist generated ui: {str(exc)}"}
             )
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            yield f"event: log\ndata: {json.dumps({'message': 'Page creation failed'})}\n\n".encode(
-                "utf-8"
-            )
+            yield _sse_event("log", {"message": "Page creation failed"})
             return
 
-        logger.info("[stream_update_ui] Sending final done event")
-        expanded_record = existing.copy()
-        expanded_record["current"] = self.service._expand_payload(existing["current"])
+        logger.info(f"{log_tag} Sending final done event")
+        expanded_record = record.copy()
+        expanded_record["current"] = self.service._expand_payload(record["current"])
         final_payload = json.dumps(
-            {"status": "updated", "record": expanded_record}, ensure_ascii=False
+            {
+                "status": "created" if existing is None else "updated",
+                "record": expanded_record,
+            },
+            ensure_ascii=False,
         )
-        yield f"event: log\ndata: {json.dumps({'message': 'Page successfully generated'})}\n\n".encode(
-            "utf-8"
-        )
+        yield _sse_event("log", {"message": "Page successfully generated"})
         yield f"event: done\ndata: {final_payload}\n\n".encode("utf-8")
         yield b"data: [DONE]\n\n"
-        logger.info("[stream_update_ui] Stream completed successfully")
+        logger.info(f"{log_tag} Stream completed successfully")
 
     async def update_ui(
         self,
@@ -1051,7 +907,7 @@ class GenerationPipeline:
             max_bytes=GENERATED_UI_MAX_TOOLS_BYTES,
         )
 
-        dummy_data = await self.service.tool_sampler._generate_dummy_data(
+        dummy_data, allowed_tools, _dummy_reused = await self._prepare_dummy_data(
             session=session,
             scope=scope,
             ui_id=ui_id,
@@ -1059,20 +915,9 @@ class GenerationPipeline:
             prompt=prompt_with_runtime,
             allowed_tools=allowed_tools,
             access_token=access_token,
+            previous=previous,
             runtime_context=runtime_context,
         )
-
-        allowed_tools, derived_schema_count = (
-            await self.service.tool_sampler._augment_tools_with_derived_output_schemas(
-                allowed_tools=allowed_tools,
-                dummy_data_module=dummy_data,
-            )
-        )
-        if derived_schema_count:
-            logger.info(
-                "[_generate_ui_payload] Added %s derived output schemas from dummy data to allowed tools",
-                derived_schema_count,
-            )
 
         messages.append(
             Message(
@@ -1119,6 +964,19 @@ class GenerationPipeline:
 
         payload = parse_json(content)
         payload["dummy_data"] = payload.get("dummy_data") or dummy_data
+        integrity_notes, integrity_errors = enforce_runtime_script_integrity(payload)
+        if integrity_notes:
+            logger.info(
+                "[_generate_ui_payload] Deduplicated runtime imports: %s",
+                "; ".join(integrity_notes),
+            )
+        if integrity_errors:
+            # Single-shot path has no retry loop; surface loudly so the
+            # follow-up test run/fixer addresses it with full context.
+            logger.warning(
+                "[_generate_ui_payload] Runtime integrity issues in generated payload: %s",
+                "; ".join(integrity_errors),
+            )
         self.service._normalise_payload(payload, scope, ui_id, name, prompt, previous)
         if prompt_compaction:
             metadata_obj = payload.get("metadata")

--- a/app/app_facade/node_test_helpers/domstubs.js
+++ b/app/app_facade/node_test_helpers/domstubs.js
@@ -1,1379 +1,1554 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
-import { createHash } from 'node:crypto';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { match } from 'node:assert';
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createHash } from "node:crypto";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { match } from "node:assert";
 
 const original = {
-  window: globalThis.window,
-  document: globalThis.document,
-  Node: globalThis.Node,
-  customElements: globalThis.customElements,
-  HTMLElement: globalThis.HTMLElement,
-  FormData: globalThis.FormData,
-  CustomEvent: globalThis.CustomEvent,
-  requestAnimationFrame: globalThis.requestAnimationFrame,
-  cancelAnimationFrame: globalThis.cancelAnimationFrame,
-  CSSStyleSheet: globalThis.CSSStyleSheet,
-  fetch: globalThis.fetch,
-  localStorage: globalThis.localStorage,
-  sessionStorage: globalThis.sessionStorage,
-  KeyboardEvent: globalThis.KeyboardEvent,
-  matchMedia: globalThis.matchMedia,
-  MutationObserver: globalThis.MutationObserver,
-  triggerMutation: globalThis.triggerMutation,
+    window: globalThis.window,
+    document: globalThis.document,
+    Node: globalThis.Node,
+    customElements: globalThis.customElements,
+    HTMLElement: globalThis.HTMLElement,
+    FormData: globalThis.FormData,
+    CustomEvent: globalThis.CustomEvent,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    cancelAnimationFrame: globalThis.cancelAnimationFrame,
+    CSSStyleSheet: globalThis.CSSStyleSheet,
+    fetch: globalThis.fetch,
+    localStorage: globalThis.localStorage,
+    sessionStorage: globalThis.sessionStorage,
+    KeyboardEvent: globalThis.KeyboardEvent,
+    matchMedia: globalThis.matchMedia,
+    MutationObserver: globalThis.MutationObserver,
+    triggerMutation: globalThis.triggerMutation,
 };
 class FakeClassList {
-  constructor() {
-    this._set = new Set();
-  }
-  add(...names) {
-    names.forEach(name => this._set.add(name));
-  }
-  remove(...names) {
-    names.forEach(name => this._set.delete(name));
-  }
-  toggle(name, force) {
-    if (force === undefined) {
-      return this._set.has(name) ? (this._set.delete(name), false) : (this._set.add(name), true);
+    constructor() {
+        this._set = new Set();
     }
-    if (force) this._set.add(name);
-    else this._set.delete(name);
-    return force;
-  }
-  contains(name) {
-    return this._set.has(name);
-  }
-  forEach(cb) {
-    this._set.forEach(cb);
-  }
-  get length() {
-    return this._set.size;
-  }
-  toString() {
-    return Array.from(this._set).join(' ');
-  }
+    add(...names) {
+        names.forEach((name) => this._set.add(name));
+    }
+    remove(...names) {
+        names.forEach((name) => this._set.delete(name));
+    }
+    toggle(name, force) {
+        if (force === undefined) {
+            return this._set.has(name)
+                ? (this._set.delete(name), false)
+                : (this._set.add(name), true);
+        }
+        if (force) this._set.add(name);
+        else this._set.delete(name);
+        return force;
+    }
+    contains(name) {
+        return this._set.has(name);
+    }
+    forEach(cb) {
+        this._set.forEach(cb);
+    }
+    get length() {
+        return this._set.size;
+    }
+    toString() {
+        return Array.from(this._set).join(" ");
+    }
 }
 
 class FakeAttributes extends Map {
-  [Symbol.iterator]() {
-    return Array.from(super.entries()).map(([name, value]) => ({ name, value }))[Symbol.iterator]();
-  }
+    [Symbol.iterator]() {
+        return Array.from(super.entries())
+            .map(([name, value]) => ({ name, value }))
+            [Symbol.iterator]();
+    }
 }
 
 let suspendConnect = false;
 const connectTree = (node) => {
-  if (suspendConnect || !node) return;
-  const walk = (current) => {
-    if (!current) return;
-    if (typeof current.connectedCallback === 'function') current.connectedCallback();
-    if (current.childNodes) current.childNodes.forEach(child => walk(child));
-    if (current.shadowRoot?.childNodes) current.shadowRoot.childNodes.forEach(child => walk(child));
-  };
-  walk(node);
+    if (suspendConnect || !node) return;
+    const walk = (current) => {
+        if (!current) return;
+        if (typeof current.connectedCallback === "function")
+            current.connectedCallback();
+        if (current.childNodes)
+            current.childNodes.forEach((child) => walk(child));
+        if (current.shadowRoot?.childNodes)
+            current.shadowRoot.childNodes.forEach((child) => walk(child));
+    };
+    walk(node);
 };
 const disconnectTree = (node) => {
-  if (!node) return;
-  const walk = (current) => {
-    if (!current) return;
-    if (typeof current.disconnectedCallback === 'function') current.disconnectedCallback();
-    if (current.childNodes) current.childNodes.forEach(child => walk(child));
-    if (current.shadowRoot?.childNodes) current.shadowRoot.childNodes.forEach(child => walk(child));
-  };
-  walk(node);
+    if (!node) return;
+    const walk = (current) => {
+        if (!current) return;
+        if (typeof current.disconnectedCallback === "function")
+            current.disconnectedCallback();
+        if (current.childNodes)
+            current.childNodes.forEach((child) => walk(child));
+        if (current.shadowRoot?.childNodes)
+            current.shadowRoot.childNodes.forEach((child) => walk(child));
+    };
+    walk(node);
 };
 const toDispatchEvent = (event) => {
-  if (typeof event === 'string') return { type: event };
-  if (!event || typeof event !== 'object') return {};
+    if (typeof event === "string") return { type: event };
+    if (!event || typeof event !== "object") return {};
 
-  const NativeEvent = globalThis.Event;
-  if (typeof NativeEvent === 'function' && event instanceof NativeEvent) {
-    const evt = {
-      type: event.type,
-      bubbles: !!event.bubbles,
-      cancelable: !!event.cancelable,
-      composed: !!event.composed,
-      defaultPrevented: !!event.defaultPrevented,
-      preventDefault() {
-        this.defaultPrevented = true;
-        event.preventDefault?.();
-      },
-      stopPropagation() {
-        this._stopped = true;
-        event.stopPropagation?.();
-      }
-    };
-    if ('detail' in event) evt.detail = event.detail;
-    return evt;
-  }
+    const NativeEvent = globalThis.Event;
+    if (typeof NativeEvent === "function" && event instanceof NativeEvent) {
+        const evt = {
+            type: event.type,
+            bubbles: !!event.bubbles,
+            cancelable: !!event.cancelable,
+            composed: !!event.composed,
+            defaultPrevented: !!event.defaultPrevented,
+            preventDefault() {
+                this.defaultPrevented = true;
+                event.preventDefault?.();
+            },
+            stopPropagation() {
+                this._stopped = true;
+                event.stopPropagation?.();
+            },
+        };
+        if ("detail" in event) evt.detail = event.detail;
+        return evt;
+    }
 
-  return event;
+    return event;
 };
 
 const matchSelector = (el, selector) => {
-  if (!selector || !el) return false;
-  const normalized = selector.trim();
-  if (!normalized) return false;
+    if (!selector || !el) return false;
+    const normalized = selector.trim();
+    if (!normalized) return false;
 
-  const splitSelectors = (input, separatorRegex) => {
-    const parts = [];
-    let current = '';
-    let attrDepth = 0;
-    let quote = null;
+    const splitSelectors = (input, separatorRegex) => {
+        const parts = [];
+        let current = "";
+        let attrDepth = 0;
+        let quote = null;
 
-    for (let i = 0; i < input.length; i++) {
-      const ch = input[i];
-      if (quote) {
-        current += ch;
-        if (ch === quote) quote = null;
-        continue;
-      }
-      if (ch === '"' || ch === '\'') {
-        quote = ch;
-        current += ch;
-        continue;
-      }
-      if (ch === '[') {
-        attrDepth++;
-        current += ch;
-        continue;
-      }
-      if (ch === ']') {
-        attrDepth = Math.max(0, attrDepth - 1);
-        current += ch;
-        continue;
-      }
+        for (let i = 0; i < input.length; i++) {
+            const ch = input[i];
+            if (quote) {
+                current += ch;
+                if (ch === quote) quote = null;
+                continue;
+            }
+            if (ch === '"' || ch === "'") {
+                quote = ch;
+                current += ch;
+                continue;
+            }
+            if (ch === "[") {
+                attrDepth++;
+                current += ch;
+                continue;
+            }
+            if (ch === "]") {
+                attrDepth = Math.max(0, attrDepth - 1);
+                current += ch;
+                continue;
+            }
 
-      if (attrDepth === 0 && separatorRegex.test(ch)) {
-        const part = current.trim();
-        if (part) parts.push(part);
-        current = '';
-        continue;
-      }
-      current += ch;
-    }
+            if (attrDepth === 0 && separatorRegex.test(ch)) {
+                const part = current.trim();
+                if (part) parts.push(part);
+                current = "";
+                continue;
+            }
+            current += ch;
+        }
 
-    const last = current.trim();
-    if (last) parts.push(last);
-    return parts;
-  };
+        const last = current.trim();
+        if (last) parts.push(last);
+        return parts;
+    };
 
-  const selectors = splitSelectors(normalized, /,/);
-  const matchesSimple = (target, sel) => {
-    let base = sel;
-    let attr = null;
-    const attrMatch = sel.match(/^(.*?)\[([^=\]]+)=\s*"?([^\]"]+)"?\s*\]$/);
-    if (attrMatch) {
-      base = attrMatch[1] || '*';
-      attr = { name: attrMatch[2], value: attrMatch[3] };
-    }
+    const selectors = splitSelectors(normalized, /,/);
+    const matchesSimple = (target, sel) => {
+        let base = sel;
+        let attr = null;
+        const attrMatch = sel.match(/^(.*?)\[([^=\]]+)=\s*"?([^\]"]+)"?\s*\]$/);
+        if (attrMatch) {
+            base = attrMatch[1] || "*";
+            attr = { name: attrMatch[2], value: attrMatch[3] };
+        }
 
-    const baseParts = base.split('.').filter(Boolean);
-    let tag = baseParts[0] || base;
-    let classes = baseParts.slice(1);
+        const baseParts = base.split(".").filter(Boolean);
+        let tag = baseParts[0] || base;
+        let classes = baseParts.slice(1);
 
-    if (base.startsWith('.')) {
-      tag = '*';
-      classes = baseParts;
-    } else if (base.startsWith('#')) {
-      return target.id === base.slice(1);
-    }
+        if (base.startsWith(".")) {
+            tag = "*";
+            classes = baseParts;
+        } else if (base.startsWith("#")) {
+            return target.id === base.slice(1);
+        }
 
-    const customMatchOnly = !base.startsWith('.') && !base.startsWith('#') && base.includes('-') && globalThis.customElements?.get?.(base);
-    const tagMatch = target.tagName?.toLowerCase() === tag.toLowerCase();
-    const classMatch = target.classList.contains(tag);
-    const idMatch = target.id === tag;
-    const tagMatches = tag === '*'
-      ? true
-      : customMatchOnly
-        ? tagMatch
-        : (tagMatch || classMatch || idMatch);
+        const customMatchOnly =
+            !base.startsWith(".") &&
+            !base.startsWith("#") &&
+            base.includes("-") &&
+            globalThis.customElements?.get?.(base);
+        const tagMatch = target.tagName?.toLowerCase() === tag.toLowerCase();
+        const classMatch = target.classList.contains(tag);
+        const idMatch = target.id === tag;
+        const tagMatches =
+            tag === "*"
+                ? true
+                : customMatchOnly
+                  ? tagMatch
+                  : tagMatch || classMatch || idMatch;
 
-    if (!tagMatches) return false;
-    if (classes.length && !classes.every(cls => target.classList.contains(cls))) return false;
-    if (attr) {
-      const val = target.getAttribute(attr.name);
-      if (val == null || String(val) !== String(attr.value)) return false;
-    }
-    return true;
-  };
+        if (!tagMatches) return false;
+        if (
+            classes.length &&
+            !classes.every((cls) => target.classList.contains(cls))
+        )
+            return false;
+        if (attr) {
+            const val = target.getAttribute(attr.name);
+            if (val == null || String(val) !== String(attr.value)) return false;
+        }
+        return true;
+    };
 
-  const findAncestorMatch = (node, sel) => {
-    let current = node?.parentNode || node?.host || null;
-    while (current) {
-      if (matchesSimple(current, sel)) return current;
-      current = current.parentNode || current.host || null;
-    }
-    return null;
-  };
+    const findAncestorMatch = (node, sel) => {
+        let current = node?.parentNode || node?.host || null;
+        while (current) {
+            if (matchesSimple(current, sel)) return current;
+            current = current.parentNode || current.host || null;
+        }
+        return null;
+    };
 
-  const matchesSingle = (sel) => {
-    const chain = splitSelectors(sel, /\s/);
-    if (!chain.length) return false;
+    const matchesSingle = (sel) => {
+        const chain = splitSelectors(sel, /\s/);
+        if (!chain.length) return false;
 
-    let current = el;
-    if (!matchesSimple(current, chain[chain.length - 1])) return false;
-    for (let i = chain.length - 2; i >= 0; i--) {
-      current = findAncestorMatch(current, chain[i]);
-      if (!current) return false;
-    }
-    return true;
-  };
+        let current = el;
+        if (!matchesSimple(current, chain[chain.length - 1])) return false;
+        for (let i = chain.length - 2; i >= 0; i--) {
+            current = findAncestorMatch(current, chain[i]);
+            if (!current) return false;
+        }
+        return true;
+    };
 
-  return selectors.some(matchesSingle);
+    return selectors.some(matchesSingle);
 };
 
 class FakeElement {
-  constructor(tagName, ownerDocument) {
-    this.tagName = String(tagName || '').toUpperCase();
-    this.nodeType = 1;
-    this.ownerDocument = ownerDocument;
-    this._childNodes = [];
-    this.dataset = {};
-    this.state = {};
-    this.classList = new FakeClassList();
-    this.attributes = new FakeAttributes();
-    this._listeners = new Map();
-    this._innerHTML = '';
-    this._textContent = '';
-    this._value = '';
-    this._checked = false;
-    this._name = '';
-    this._type = '';
-    this._action = '';
-  }
-  get className() {
-    return this.classList.toString();
-  }
-  set className(value) {
-    this.classList = new FakeClassList();
-    const names = String(value ?? '').split(/\s+/).filter(Boolean);
-    this.classList.add(...names);
-  }
-  attachInternals() {
-    if (!this._internals) {
-      this._internals = {
-        _element: this,
-        setFormValue(v) {},
-        setValidity(flags, message) {
-           this.flags = flags || {};
-           this.validationMessage = message || '';
-           this.validity = { 
-               valid: !Object.keys(flags || {}).length,
-               customError: !!flags?.customError,
-               ...flags
-           };
-        },
-        validity: { valid: true },
-        validationMessage: '',
-        checkValidity() { return this.validity.valid; },
-        reportValidity() { return this.validity.valid; }
-      };
+    constructor(tagName, ownerDocument) {
+        this.tagName = String(tagName || "").toUpperCase();
+        this.nodeType = 1;
+        this.ownerDocument = ownerDocument;
+        this._childNodes = [];
+        this.dataset = {};
+        this.state = {};
+        this.classList = new FakeClassList();
+        this.attributes = new FakeAttributes();
+        this._listeners = new Map();
+        this._innerHTML = "";
+        this._textContent = "";
+        this._value = "";
+        this._checked = false;
+        this._name = "";
+        this._type = "";
+        this._action = "";
     }
-    return this._internals;
-  }
-  attachShadow() {
-    this.shadowRoot = new FakeShadowRoot(this.ownerDocument, this);
-    return this.shadowRoot;
-  }
-  appendChild(node) {
-    if (!node) return node;
-    if (node.parentNode) {
-      if (node.parentNode !== this) node.parentNode.removeChild?.(node);
-      else {
-        const existingIndex = this._childNodes.indexOf(node);
-        if (existingIndex >= 0) this._childNodes.splice(existingIndex, 1);
-      }
+    get className() {
+        return this.classList.toString();
     }
-    this._childNodes.push(node);
-    if (typeof node === 'object') {
-      node.parentNode = this;
-      if (!node.ownerDocument && this.ownerDocument) node.ownerDocument = this.ownerDocument;
+    set className(value) {
+        this.classList = new FakeClassList();
+        const names = String(value ?? "")
+            .split(/\s+/)
+            .filter(Boolean);
+        this.classList.add(...names);
     }
-    connectTree(node);
-    return node;
-  }
-  insertBefore(newNode, referenceNode) {
-    if (!referenceNode) return this.appendChild(newNode);
-    const index = this._childNodes.indexOf(referenceNode);
-    if (index === -1) return this.appendChild(newNode);
-    if (newNode?.parentNode) {
-      if (newNode.parentNode !== this) newNode.parentNode.removeChild?.(newNode);
-      else {
-        const existingIndex = this._childNodes.indexOf(newNode);
-        if (existingIndex >= 0) this._childNodes.splice(existingIndex, 1);
-      }
-    }
-    this._childNodes.splice(index, 0, newNode);
-    if (typeof newNode === 'object') {
-      newNode.parentNode = this;
-      if (!newNode.ownerDocument && this.ownerDocument) newNode.ownerDocument = this.ownerDocument;
-    }
-    connectTree(newNode);
-    return newNode;
-  }
-  removeChild(node) {
-    const index = this._childNodes.indexOf(node);
-    if (index >= 0) {
-      this._childNodes.splice(index, 1);
-      disconnectTree(node);
-      if (node && typeof node === 'object') node.parentNode = null;
-    }
-  }
-  replaceWith(node) {
-    if (!this.parentNode) return;
-    const index = this.parentNode._childNodes.indexOf(this);
-    if (index >= 0) {
-      disconnectTree(this);
-      this.parentNode._childNodes.splice(index, 1, node);
-      node.parentNode = this.parentNode;
-      connectTree(node);
-    }
-  }
-  get childNodes() {
-    return this._childNodes.filter(child => child?.parentNode === this);
-  }
-  remove() {
-    if (this.parentNode) this.parentNode.removeChild(this);
-  }
-  get children() {
-    return this.childNodes.filter(child => child?.nodeType === 1);
-  }
-  get firstElementChild() {
-    return this.children[0] || null;
-  }
-  get nextElementSibling() {
-    if (!this.parentNode) return null;
-    const siblings = this.parentNode.children;
-    const index = siblings.indexOf(this);
-    return index >= 0 ? siblings[index + 1] || null : null;
-  }
-  get previousElementSibling() {
-    if (!this.parentNode) return null;
-    const siblings = this.parentNode.children;
-    const index = siblings.indexOf(this);
-    return index > 0 ? siblings[index - 1] || null : null;
-  }
-  setAttribute(name, value) {
-    const stringValue = String(value);
-    const prev = this.attributes.has(name) ? this.attributes.get(name) : null;
-    this.attributes.set(name, stringValue);
-    if (name === 'id') this.id = value;
-    if (name === 'class') {
-      this.classList = new FakeClassList();
-      const classes = String(value).split(/\s+/).filter(Boolean);
-      classes.forEach(cls => this.classList.add(cls));
-    }
-    if (name === 'value') {
-      this._value = String(value ?? '');
-    }
-    if (name === 'checked') {
-      this._checked = value !== false && value !== null && value !== 'false';
-    }
-    if (name === 'name') {
-      this.name = String(value ?? '');
-    }
-    if (name === 'type') {
-      this.type = String(value ?? '');
-    }
-    if (name === 'action') {
-      this.action = String(value ?? '');
-    }
-    if (typeof this.attributeChangedCallback === 'function' && prev !== stringValue) {
-      // console.log(`STUB: Attribute ${name} changed from ${prev} to ${stringValue} on ${this.tagName}`);
-      this.attributeChangedCallback(name, prev, stringValue);
-    }
-  }
-  get isConnected() { return !!this.parentNode; }
-  getAttribute(name) {
-    return this.attributes.has(name) ? this.attributes.get(name) : null;
-  }
-  hasAttribute(name) {
-    return this.attributes.has(name);
-  }
-  removeAttribute(name) {
-    const prev = this.attributes.has(name) ? this.attributes.get(name) : null;
-    this.attributes.delete(name);
-    if (name === 'id') this.id = undefined;
-    if (name === 'class') this.classList = new FakeClassList();
-    if (name === 'value') this._value = '';
-    if (name === 'checked') this._checked = false;
-    if (name === 'name') this._name = '';
-    if (name === 'type') this._type = '';
-    
-    if (typeof this.attributeChangedCallback === 'function' && prev !== null) {
-      this.attributeChangedCallback(name, prev, null);
-    }
-  }
-  addEventListener(type, handler) {
-    if (!this._listeners.has(type)) this._listeners.set(type, new Set());
-    this._listeners.get(type).add(handler);
-  }
-  removeEventListener(type, handler) {
-    this._listeners.get(type)?.delete(handler);
-  }
-  dispatchEvent(event) {
-    const evt = toDispatchEvent(event);
-    evt.preventDefault ??= () => { evt.defaultPrevented = true; };
-    evt.stopPropagation ??= () => { evt._stopped = true; };
-    const handlers = Array.from(this._listeners.get(evt?.type) || []);
-    try {
-      if (evt && evt.target == null) evt.target = this;
-      evt.currentTarget = this;
-    } catch (err) {
-      /* ignore read-only target */
-    }
-    handlers.forEach(handler => handler.call(this, evt));
-    if (evt.bubbles && !evt._stopped) {
-      if (this.parentNode?.dispatchEvent) {
-        return this.parentNode.dispatchEvent(evt);
-      }
-      const win = this.ownerDocument?.defaultView || globalThis.window;
-      if (win?.dispatchEvent) return win.dispatchEvent(evt);
-    }
-    return true;
-  }
-  contains(node) {
-    return this === node || this.childNodes.some(child => child === node || (child.contains && child.contains(node)));
-  }
-  getRootNode(options) {
-    let current = this;
-    while (current.parentNode) {
-      current = current.parentNode;
-    }
-    return current;
-  }
-  closest(selector) {
-    if (!selector) return null;
-    let current = this;
-    while (current) {
-      if (current.matches?.(selector)) return current;
-      current = current.parentNode || current.host;
-    }
-    return null;
-  }
-  focus() {
-    if (this.ownerDocument) this.ownerDocument.activeElement = this;
-  }
-  blur() {
-    if (this.ownerDocument && this.ownerDocument.activeElement === this) {
-      this.ownerDocument.activeElement = null;
-    }
-  }
-  get innerHTML() {
-    return this._innerHTML;
-  }
-  set innerHTML(value) {
-    this._childNodes.forEach(child => disconnectTree(child));
-    this._innerHTML = String(value ?? '');
-    this._childNodes = [];
-    this._textContent = '';
-  }
-  get textContent() {
-    if (this.childNodes.length) {
-      return this.childNodes.map(node => node.nodeType === 3 ? (node.textContent || '') : (node.textContent || '')).join('');
-    }
-    return this._textContent;
-  }
-  set textContent(value) {
-    this._childNodes.forEach(child => disconnectTree(child));
-    this._childNodes = [];
-    this._textContent = String(value ?? '');
-  }
-  get value() {
-    return this._value;
-  }
-  set value(val) {
-    this._value = String(val ?? '');
-    this.attributes.set('value', this._value);
-  }
-  get checked() {
-    return !!this._checked;
-  }
-  set checked(val) {
-    this._checked = !!val;
-    if (this._checked) this.attributes.set('checked', '');
-    else this.attributes.delete('checked');
-  }
-  get name() {
-    return this._name;
-  }
-  set name(val) {
-    this._name = String(val ?? '');
-    this.attributes.set('name', this._name);
-  }
-  get type() {
-    return this._type;
-  }
-  set type(val) {
-    this._type = String(val ?? '');
-    this.attributes.set('type', this._type);
-  }
-  get action() {
-    return this._action || this.getAttribute('action') || '';
-  }
-  set action(val) {
-    this._action = String(val ?? '');
-    this.attributes.set('action', this._action);
-  }
-  getRootNode() {
-    return this.ownerDocument || this;
-  }
-  getElementById(id) {
-    return this.querySelector(`#${id}`);
-  }
-  querySelector(selector) {
-    return this.querySelectorAll(selector)[0] || null;
-  }
-  querySelectorAll(selector) {
-    const results = [];
-    const walk = (node) => {
-      if (!node || !node.childNodes) return;
-      node.childNodes.forEach(child => {
-        if (child?.matches?.(selector)) results.push(child);
-        walk(child);
-        if (child.shadowRoot) walk(child.shadowRoot);
-      });
-    };
-    walk(this);
-    return results;
-  }
-  matches(selector) {
-    return matchSelector(this, selector);
-  }
-  submit() {
-    this.dispatchEvent({
-      type: 'submit',
-      target: this,
-      preventDefault() { this.defaultPrevented = true; }
-    });
-  }
-  click() {
-    if (this.type === 'checkbox') {
-      this.checked = !this.checked;
-      this.dispatchEvent({ type: 'click', target: this });
-      this.dispatchEvent({ type: 'change', target: this });
-      return;
-    }
-    this.dispatchEvent({ type: 'click', target: this });
-  }
-  reset() {
-    const resetChild = (node) => {
-      if (!node || !node.childNodes) return;
-      node.childNodes.forEach(child => {
-        if (child instanceof FakeElement) {
-          if (child.tagName === 'INPUT' || child.tagName === 'TEXTAREA') {
-            child.value = '';
-            if (child.type === 'checkbox') child.checked = false;
-          }
+    attachInternals() {
+        if (!this._internals) {
+            this._internals = {
+                _element: this,
+                setFormValue(v) {},
+                setValidity(flags, message) {
+                    this.flags = flags || {};
+                    this.validationMessage = message || "";
+                    this.validity = {
+                        valid: !Object.keys(flags || {}).length,
+                        customError: !!flags?.customError,
+                        ...flags,
+                    };
+                },
+                validity: { valid: true },
+                validationMessage: "",
+                checkValidity() {
+                    return this.validity.valid;
+                },
+                reportValidity() {
+                    return this.validity.valid;
+                },
+            };
         }
-        resetChild(child);
-      });
-    };
-    resetChild(this);
-  }
+        return this._internals;
+    }
+    attachShadow() {
+        this.shadowRoot = new FakeShadowRoot(this.ownerDocument, this);
+        return this.shadowRoot;
+    }
+    appendChild(node) {
+        if (!node) return node;
+        if (node.parentNode) {
+            if (node.parentNode !== this) node.parentNode.removeChild?.(node);
+            else {
+                const existingIndex = this._childNodes.indexOf(node);
+                if (existingIndex >= 0)
+                    this._childNodes.splice(existingIndex, 1);
+            }
+        }
+        this._childNodes.push(node);
+        if (typeof node === "object") {
+            node.parentNode = this;
+            if (!node.ownerDocument && this.ownerDocument)
+                node.ownerDocument = this.ownerDocument;
+        }
+        connectTree(node);
+        return node;
+    }
+    insertBefore(newNode, referenceNode) {
+        if (!referenceNode) return this.appendChild(newNode);
+        const index = this._childNodes.indexOf(referenceNode);
+        if (index === -1) return this.appendChild(newNode);
+        if (newNode?.parentNode) {
+            if (newNode.parentNode !== this)
+                newNode.parentNode.removeChild?.(newNode);
+            else {
+                const existingIndex = this._childNodes.indexOf(newNode);
+                if (existingIndex >= 0)
+                    this._childNodes.splice(existingIndex, 1);
+            }
+        }
+        this._childNodes.splice(index, 0, newNode);
+        if (typeof newNode === "object") {
+            newNode.parentNode = this;
+            if (!newNode.ownerDocument && this.ownerDocument)
+                newNode.ownerDocument = this.ownerDocument;
+        }
+        connectTree(newNode);
+        return newNode;
+    }
+    removeChild(node) {
+        const index = this._childNodes.indexOf(node);
+        if (index >= 0) {
+            this._childNodes.splice(index, 1);
+            disconnectTree(node);
+            if (node && typeof node === "object") node.parentNode = null;
+        }
+    }
+    replaceWith(node) {
+        if (!this.parentNode) return;
+        const index = this.parentNode._childNodes.indexOf(this);
+        if (index >= 0) {
+            disconnectTree(this);
+            this.parentNode._childNodes.splice(index, 1, node);
+            node.parentNode = this.parentNode;
+            connectTree(node);
+        }
+    }
+    get childNodes() {
+        return this._childNodes.filter((child) => child?.parentNode === this);
+    }
+    remove() {
+        if (this.parentNode) this.parentNode.removeChild(this);
+    }
+    get children() {
+        return this.childNodes.filter((child) => child?.nodeType === 1);
+    }
+    get firstElementChild() {
+        return this.children[0] || null;
+    }
+    get nextElementSibling() {
+        if (!this.parentNode) return null;
+        const siblings = this.parentNode.children;
+        const index = siblings.indexOf(this);
+        return index >= 0 ? siblings[index + 1] || null : null;
+    }
+    get previousElementSibling() {
+        if (!this.parentNode) return null;
+        const siblings = this.parentNode.children;
+        const index = siblings.indexOf(this);
+        return index > 0 ? siblings[index - 1] || null : null;
+    }
+    setAttribute(name, value) {
+        const stringValue = String(value);
+        const prev = this.attributes.has(name)
+            ? this.attributes.get(name)
+            : null;
+        this.attributes.set(name, stringValue);
+        if (name === "id") this.id = value;
+        if (name === "class") {
+            this.classList = new FakeClassList();
+            const classes = String(value).split(/\s+/).filter(Boolean);
+            classes.forEach((cls) => this.classList.add(cls));
+        }
+        if (name === "value") {
+            this._value = String(value ?? "");
+        }
+        if (name === "checked") {
+            this._checked =
+                value !== false && value !== null && value !== "false";
+        }
+        if (name === "name") {
+            this.name = String(value ?? "");
+        }
+        if (name === "type") {
+            this.type = String(value ?? "");
+        }
+        if (name === "action") {
+            this.action = String(value ?? "");
+        }
+        if (
+            typeof this.attributeChangedCallback === "function" &&
+            prev !== stringValue
+        ) {
+            // console.log(`STUB: Attribute ${name} changed from ${prev} to ${stringValue} on ${this.tagName}`);
+            this.attributeChangedCallback(name, prev, stringValue);
+        }
+    }
+    get isConnected() {
+        return !!this.parentNode;
+    }
+    getAttribute(name) {
+        return this.attributes.has(name) ? this.attributes.get(name) : null;
+    }
+    hasAttribute(name) {
+        return this.attributes.has(name);
+    }
+    removeAttribute(name) {
+        const prev = this.attributes.has(name)
+            ? this.attributes.get(name)
+            : null;
+        this.attributes.delete(name);
+        if (name === "id") this.id = undefined;
+        if (name === "class") this.classList = new FakeClassList();
+        if (name === "value") this._value = "";
+        if (name === "checked") this._checked = false;
+        if (name === "name") this._name = "";
+        if (name === "type") this._type = "";
+
+        if (
+            typeof this.attributeChangedCallback === "function" &&
+            prev !== null
+        ) {
+            this.attributeChangedCallback(name, prev, null);
+        }
+    }
+    addEventListener(type, handler) {
+        if (!this._listeners.has(type)) this._listeners.set(type, new Set());
+        this._listeners.get(type).add(handler);
+    }
+    removeEventListener(type, handler) {
+        this._listeners.get(type)?.delete(handler);
+    }
+    dispatchEvent(event) {
+        const evt = toDispatchEvent(event);
+        evt.preventDefault ??= () => {
+            evt.defaultPrevented = true;
+        };
+        evt.stopPropagation ??= () => {
+            evt._stopped = true;
+        };
+        const handlers = Array.from(this._listeners.get(evt?.type) || []);
+        try {
+            if (evt && evt.target == null) evt.target = this;
+            evt.currentTarget = this;
+        } catch (err) {
+            /* ignore read-only target */
+        }
+        handlers.forEach((handler) => handler.call(this, evt));
+        if (evt.bubbles && !evt._stopped) {
+            if (this.parentNode?.dispatchEvent) {
+                return this.parentNode.dispatchEvent(evt);
+            }
+            const win = this.ownerDocument?.defaultView || globalThis.window;
+            if (win?.dispatchEvent) return win.dispatchEvent(evt);
+        }
+        return true;
+    }
+    contains(node) {
+        return (
+            this === node ||
+            this.childNodes.some(
+                (child) =>
+                    child === node || (child.contains && child.contains(node)),
+            )
+        );
+    }
+    getRootNode(options) {
+        let current = this;
+        while (current.parentNode) {
+            current = current.parentNode;
+        }
+        return current;
+    }
+    closest(selector) {
+        if (!selector) return null;
+        let current = this;
+        while (current) {
+            if (current.matches?.(selector)) return current;
+            current = current.parentNode || current.host;
+        }
+        return null;
+    }
+    focus() {
+        if (this.ownerDocument) this.ownerDocument.activeElement = this;
+    }
+    blur() {
+        if (this.ownerDocument && this.ownerDocument.activeElement === this) {
+            this.ownerDocument.activeElement = null;
+        }
+    }
+    get innerHTML() {
+        return this._innerHTML;
+    }
+    set innerHTML(value) {
+        this._childNodes.forEach((child) => disconnectTree(child));
+        this._innerHTML = String(value ?? "");
+        this._childNodes = [];
+        this._textContent = "";
+    }
+    get textContent() {
+        if (this.childNodes.length) {
+            return this.childNodes
+                .map((node) =>
+                    node.nodeType === 3
+                        ? node.textContent || ""
+                        : node.textContent || "",
+                )
+                .join("");
+        }
+        return this._textContent;
+    }
+    set textContent(value) {
+        this._childNodes.forEach((child) => disconnectTree(child));
+        this._childNodes = [];
+        this._textContent = String(value ?? "");
+    }
+    get value() {
+        return this._value;
+    }
+    set value(val) {
+        this._value = String(val ?? "");
+        this.attributes.set("value", this._value);
+    }
+    get checked() {
+        return !!this._checked;
+    }
+    set checked(val) {
+        this._checked = !!val;
+        if (this._checked) this.attributes.set("checked", "");
+        else this.attributes.delete("checked");
+    }
+    get name() {
+        return this._name;
+    }
+    set name(val) {
+        this._name = String(val ?? "");
+        this.attributes.set("name", this._name);
+    }
+    get type() {
+        return this._type;
+    }
+    set type(val) {
+        this._type = String(val ?? "");
+        this.attributes.set("type", this._type);
+    }
+    get action() {
+        return this._action || this.getAttribute("action") || "";
+    }
+    set action(val) {
+        this._action = String(val ?? "");
+        this.attributes.set("action", this._action);
+    }
+    getRootNode() {
+        return this.ownerDocument || this;
+    }
+    getElementById(id) {
+        return this.querySelector(`#${id}`);
+    }
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+    querySelectorAll(selector) {
+        const results = [];
+        const walk = (node) => {
+            if (!node || !node.childNodes) return;
+            node.childNodes.forEach((child) => {
+                if (child?.matches?.(selector)) results.push(child);
+                walk(child);
+                if (child.shadowRoot) walk(child.shadowRoot);
+            });
+        };
+        walk(this);
+        return results;
+    }
+    matches(selector) {
+        return matchSelector(this, selector);
+    }
+    submit() {
+        this.dispatchEvent({
+            type: "submit",
+            target: this,
+            preventDefault() {
+                this.defaultPrevented = true;
+            },
+        });
+    }
+    click() {
+        if (this.type === "checkbox") {
+            this.checked = !this.checked;
+            this.dispatchEvent({ type: "click", target: this });
+            this.dispatchEvent({ type: "change", target: this });
+            return;
+        }
+        this.dispatchEvent({ type: "click", target: this });
+    }
+    reset() {
+        const resetChild = (node) => {
+            if (!node || !node.childNodes) return;
+            node.childNodes.forEach((child) => {
+                if (child instanceof FakeElement) {
+                    if (
+                        child.tagName === "INPUT" ||
+                        child.tagName === "TEXTAREA"
+                    ) {
+                        child.value = "";
+                        if (child.type === "checkbox") child.checked = false;
+                    }
+                }
+                resetChild(child);
+            });
+        };
+        resetChild(this);
+    }
 }
 
 class FakeShadowRoot extends FakeElement {
-  constructor(ownerDocument, host) {
-    super('#shadow-root', ownerDocument);
-    this.host = host;
-    this.adoptedStyleSheets = [];
-  }
+    constructor(ownerDocument, host) {
+        super("#shadow-root", ownerDocument);
+        this.host = host;
+        this.adoptedStyleSheets = [];
+    }
 }
 
 class FakeHTMLElement extends FakeElement {
-  constructor(tagName, ownerDocument) {
-    super(tagName, ownerDocument);
-  }
+    constructor(tagName, ownerDocument) {
+        super(tagName, ownerDocument);
+    }
 }
 
 // --- MutationObserver Mock Support ---
 let _mutationObservers = [];
 
-
 class FakeMutationObserver {
-  constructor(callback) {
-    this.callback = callback;
-    this._records = [];
-    this._observed = [];
-    this._active = false;
-    _mutationObservers.push(this);
-  }
-  observe(target, options) {
-    this._observed.push({ target, options: options || {} });
-    this._active = true;
-  }
-  disconnect() {
-    this._active = false;
-    this._observed = [];
-  }
-  takeRecords() {
-    const records = this._records.slice();
-    this._records = [];
-    return records;
-  }
-  _enqueue(record) {
-    if (this._active) {
-      this._records.push(record);
+    constructor(callback) {
+        this.callback = callback;
+        this._records = [];
+        this._observed = [];
+        this._active = false;
+        _mutationObservers.push(this);
     }
-  }
+    observe(target, options) {
+        this._observed.push({ target, options: options || {} });
+        this._active = true;
+    }
+    disconnect() {
+        this._active = false;
+        this._observed = [];
+    }
+    takeRecords() {
+        const records = this._records.slice();
+        this._records = [];
+        return records;
+    }
+    _enqueue(record) {
+        if (this._active) {
+            this._records.push(record);
+        }
+    }
 }
 
 function isDescendantOrSelf(parent, node) {
-  if (!parent || !node) return false;
-  if (parent === node) return true;
-  let current = node.parentNode;
-  while (current) {
-    if (current === parent) return true;
-    current = current.parentNode;
-  }
-  return false;
+    if (!parent || !node) return false;
+    if (parent === node) return true;
+    let current = node.parentNode;
+    while (current) {
+        if (current === parent) return true;
+        current = current.parentNode;
+    }
+    return false;
 }
 
 function triggerMutation(target, record = null) {
-  // record: { type, target, addedNodes, removedNodes, attributeName, oldValue, ... }
-  _mutationObservers.forEach(observer => {
-    if (!observer._active) return;
-    for (const { target: observedTarget, options } of observer._observed) {
-      if (observedTarget === target) {
-        observer.callback([record || { type: 'childList', target, addedNodes: [], removedNodes: [] }], observer);
-        return;
-      }
-      if (options && options.subtree && isDescendantOrSelf(observedTarget, target)) {
-        observer.callback([record || { type: 'childList', target, addedNodes: [], removedNodes: [] }], observer);
-        return;
-      }
-    }
-  });
+    // record: { type, target, addedNodes, removedNodes, attributeName, oldValue, ... }
+    _mutationObservers.forEach((observer) => {
+        if (!observer._active) return;
+        for (const { target: observedTarget, options } of observer._observed) {
+            if (observedTarget === target) {
+                observer.callback(
+                    [
+                        record || {
+                            type: "childList",
+                            target,
+                            addedNodes: [],
+                            removedNodes: [],
+                        },
+                    ],
+                    observer,
+                );
+                return;
+            }
+            if (
+                options &&
+                options.subtree &&
+                isDescendantOrSelf(observedTarget, target)
+            ) {
+                observer.callback(
+                    [
+                        record || {
+                            type: "childList",
+                            target,
+                            addedNodes: [],
+                            removedNodes: [],
+                        },
+                    ],
+                    observer,
+                );
+                return;
+            }
+        }
+    });
 }
 
 class FakeCustomEvent {
-  constructor(type, options = {}) {
-    this.type = type;
-    this.detail = options.detail;
-    this.bubbles = !!options.bubbles;
-    this.composed = !!options.composed;
-    this.target = null;
-    this.defaultPrevented = false;
-  }
-  preventDefault() {
-    this.defaultPrevented = true;
-  }
-  set currentTarget(value) {
-    this.target = value;
-  }
-  get currentTarget() {
-    return this.target;
-  }
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail;
+        this.bubbles = !!options.bubbles;
+        this.composed = !!options.composed;
+        this.target = null;
+        this.defaultPrevented = false;
+    }
+    preventDefault() {
+        this.defaultPrevented = true;
+    }
+    set currentTarget(value) {
+        this.target = value;
+    }
+    get currentTarget() {
+        return this.target;
+    }
 }
 
 class FakeRange {
-  constructor(context = null) {
-    this.context = context;
-    this.lastNode = null;
-  }
-  selectNodeContents(element) {
-    this.context = element;
-  }
-  collapse() {
-    /* no-op */
-  }
-  insertNode(node) {
-    if (this.context) {
-      this.context.appendChild(node);
-      this.lastNode = node;
+    constructor(context = null) {
+        this.context = context;
+        this.lastNode = null;
     }
-  }
-  setStartAfter(node) {
-    this.lastNode = node;
-  }
-  deleteContents() {
-    if (this.context) this.context._childNodes = [];
-  }
-  cloneRange() {
-    const clone = new FakeRange(this.context);
-    clone.lastNode = this.lastNode;
-    return clone;
-  }
+    selectNodeContents(element) {
+        this.context = element;
+    }
+    collapse() {
+        /* no-op */
+    }
+    insertNode(node) {
+        if (this.context) {
+            this.context.appendChild(node);
+            this.lastNode = node;
+        }
+    }
+    setStartAfter(node) {
+        this.lastNode = node;
+    }
+    deleteContents() {
+        if (this.context) this.context._childNodes = [];
+    }
+    cloneRange() {
+        const clone = new FakeRange(this.context);
+        clone.lastNode = this.lastNode;
+        return clone;
+    }
 }
 
 class FakeSelection {
-  constructor() {
-    this._ranges = [];
-    this.anchorNode = null;
-  }
-  get rangeCount() {
-    return this._ranges.length;
-  }
-  getRangeAt(index) {
-    return this._ranges[index];
-  }
-  removeAllRanges() {
-    this._ranges = [];
-    this.anchorNode = null;
-  }
-  addRange(range) {
-    this._ranges = [range];
-    this.anchorNode = range.context || range.lastNode || null;
-  }
-  deleteFromDocument() {
-    const range = this._ranges[0];
-    if (range?.context) range.context._childNodes = [];
-  }
-  collapseToEnd() {
-    /* no-op */
-  }
+    constructor() {
+        this._ranges = [];
+        this.anchorNode = null;
+    }
+    get rangeCount() {
+        return this._ranges.length;
+    }
+    getRangeAt(index) {
+        return this._ranges[index];
+    }
+    removeAllRanges() {
+        this._ranges = [];
+        this.anchorNode = null;
+    }
+    addRange(range) {
+        this._ranges = [range];
+        this.anchorNode = range.context || range.lastNode || null;
+    }
+    deleteFromDocument() {
+        const range = this._ranges[0];
+        if (range?.context) range.context._childNodes = [];
+    }
+    collapseToEnd() {
+        /* no-op */
+    }
 }
 
 class FakeFormData {
-  constructor(form) {
-    this._entries = [];
-    if (form) {
-      const collect = (node) => {
-        if (!node || !node.childNodes) return;
-        node.childNodes.forEach(child => {
-          if (child instanceof FakeElement) {
-            const name = child.name || child.getAttribute('name');
-            if (name) {
-              this._entries.push([name, child.value]);
-            }
-          }
-          collect(child);
-        });
-      };
-      collect(form);
+    constructor(form) {
+        this._entries = [];
+        if (form) {
+            const collect = (node) => {
+                if (!node || !node.childNodes) return;
+                node.childNodes.forEach((child) => {
+                    if (child instanceof FakeElement) {
+                        const name = child.name || child.getAttribute("name");
+                        if (name) {
+                            this._entries.push([name, child.value]);
+                        }
+                    }
+                    collect(child);
+                });
+            };
+            collect(form);
+        }
     }
-  }
-  get(name) {
-    const entry = this._entries.find(([k]) => k === name);
-    return entry ? entry[1] : null;
-  }
-  append(name, value) {
-    this._entries.push([name, value]);
-  }
-  entries() {
-    return this._entries[Symbol.iterator]();
-  }
-  [Symbol.iterator]() {
-    return this.entries();
-  }
+    get(name) {
+        const entry = this._entries.find(([k]) => k === name);
+        return entry ? entry[1] : null;
+    }
+    append(name, value) {
+        this._entries.push([name, value]);
+    }
+    entries() {
+        return this._entries[Symbol.iterator]();
+    }
+    [Symbol.iterator]() {
+        return this.entries();
+    }
 }
 
 class FakeDocument {
-  constructor(selection, messageListeners) {
-    this.activeElement = null;
-    this._selection = selection;
-    this._messageListeners = messageListeners;
-    this._listeners = new Map();
-    this.body = new FakeElement('body', this);
-    this.documentElement = new FakeElement('html', this);
-    this.cookie = '';
-  }
-  createElement(tag) {
-    const name = String(tag || '');
-    const registry = globalThis.customElements;
-    const Ctor = registry?.get?.(name);
-    let element;
-    if (Ctor) {
-      element = new Ctor();
-      element.tagName = name.toUpperCase();
-    } else {
-      element = new FakeElement(name, this);
+    constructor(selection, messageListeners) {
+        this.activeElement = null;
+        this._selection = selection;
+        this._messageListeners = messageListeners;
+        this._listeners = new Map();
+        this.body = new FakeElement("body", this);
+        this.documentElement = new FakeElement("html", this);
+        this.cookie = "";
     }
-    element.ownerDocument = this;
-    return element;
-  }
-  createTextNode(text) {
-    return {
-      nodeType: 3,
-      textContent: String(text ?? ''),
-      remove() {
-        this.parentNode?.removeChild?.(this);
-      }
-    };
-  }
-  createRange() {
-    return new FakeRange();
-  }
-  querySelectorAll(selector) {
-    return this.body.querySelectorAll(selector);
-  }
-  querySelector(selector) {
-    return this.body.querySelector(selector);
-  }
-  execCommand() {
-    /* no-op */
-  }
-  queryCommandSupported() {
-    return false;
-  }
-  addEventListener(type, handler) {
-    if (!this._listeners.has(type)) this._listeners.set(type, new Set());
-    this._listeners.get(type).add(handler);
-  }
-  removeEventListener(type, handler) {
-    this._listeners.get(type)?.delete(handler);
-  }
-  dispatchEvent(event) {
-    const evt = toDispatchEvent(event);
-    evt.preventDefault ??= () => { evt.defaultPrevented = true; };
-    evt.stopPropagation ??= () => { evt._stopped = true; };
-    const handlers = this._listeners.get(evt?.type) || new Set();
-    try {
-      if (evt && evt.target == null) evt.target = this;
-      evt.currentTarget = this;
-    } catch (err) {
-      /* ignore read-only target/currentTarget on native events */
+    createElement(tag) {
+        const name = String(tag || "");
+        const registry = globalThis.customElements;
+        const Ctor = registry?.get?.(name);
+        let element;
+        if (Ctor) {
+            element = new Ctor();
+            element.tagName = name.toUpperCase();
+        } else {
+            element = new FakeElement(name, this);
+        }
+        element.ownerDocument = this;
+        return element;
     }
-    handlers.forEach(handler => handler.call(this, evt));
-    if (evt.bubbles && !evt._stopped) {
-      const win = this.defaultView || globalThis.window;
-      if (win?.dispatchEvent) return win.dispatchEvent(evt);
+    createTextNode(text) {
+        return {
+            nodeType: 3,
+            textContent: String(text ?? ""),
+            remove() {
+                this.parentNode?.removeChild?.(this);
+            },
+        };
     }
-    return true;
-  }
+    createRange() {
+        return new FakeRange();
+    }
+    querySelectorAll(selector) {
+        return this.body.querySelectorAll(selector);
+    }
+    querySelector(selector) {
+        return this.body.querySelector(selector);
+    }
+    execCommand() {
+        /* no-op */
+    }
+    queryCommandSupported() {
+        return false;
+    }
+    addEventListener(type, handler) {
+        if (!this._listeners.has(type)) this._listeners.set(type, new Set());
+        this._listeners.get(type).add(handler);
+    }
+    removeEventListener(type, handler) {
+        this._listeners.get(type)?.delete(handler);
+    }
+    dispatchEvent(event) {
+        const evt = toDispatchEvent(event);
+        evt.preventDefault ??= () => {
+            evt.defaultPrevented = true;
+        };
+        evt.stopPropagation ??= () => {
+            evt._stopped = true;
+        };
+        const handlers = this._listeners.get(evt?.type) || new Set();
+        try {
+            if (evt && evt.target == null) evt.target = this;
+            evt.currentTarget = this;
+        } catch (err) {
+            /* ignore read-only target/currentTarget on native events */
+        }
+        handlers.forEach((handler) => handler.call(this, evt));
+        if (evt.bubbles && !evt._stopped) {
+            const win = this.defaultView || globalThis.window;
+            if (win?.dispatchEvent) return win.dispatchEvent(evt);
+        }
+        return true;
+    }
 }
 
 class FakeWindow {
-  constructor(selection, messageListeners) {
-    this._selection = selection;
-    this._listeners = messageListeners || new Map();
-    this.location = {
-      origin: 'http://localhost',
-      hostname: 'localhost',
-      pathname: '/',
-      search: '',
-      hash: '',
-      href: 'http://localhost/'
-    };
-    this.document = null;
-  }
-  addEventListener(type, handler) {
-    if (!this._listeners.has(type)) this._listeners.set(type, new Set());
-    this._listeners.get(type).add(handler);
-  }
-  removeEventListener(type, handler) {
-    this._listeners.get(type)?.delete(handler);
-  }
-  dispatchEvent(event) {
-    const evt = toDispatchEvent(event);
-    evt.preventDefault ??= () => { evt.defaultPrevented = true; };
-    evt.stopPropagation ??= () => { evt._stopped = true; };
-    const handlers = this._listeners.get(evt?.type) || new Set();
-    try {
-      if (evt && evt.target == null) evt.target = this;
-      evt.currentTarget = this;
-    } catch (err) {
-      /* ignore read-only target/currentTarget on native events */
+    constructor(selection, messageListeners) {
+        this._selection = selection;
+        this._listeners = messageListeners || new Map();
+        this.location = {
+            origin: "http://localhost",
+            hostname: "localhost",
+            pathname: "/",
+            search: "",
+            hash: "",
+            href: "http://localhost/",
+        };
+        this.document = null;
     }
-    handlers.forEach(handler => handler.call(this, evt));
-    return true;
-  }
-  postMessage(data) {
-    const handlers = this._listeners.get('message') || new Set();
-    handlers.forEach(handler => handler({ data }));
-  }
-  getSelection() {
-    return this._selection;
-  }
+    addEventListener(type, handler) {
+        if (!this._listeners.has(type)) this._listeners.set(type, new Set());
+        this._listeners.get(type).add(handler);
+    }
+    removeEventListener(type, handler) {
+        this._listeners.get(type)?.delete(handler);
+    }
+    dispatchEvent(event) {
+        const evt = toDispatchEvent(event);
+        evt.preventDefault ??= () => {
+            evt.defaultPrevented = true;
+        };
+        evt.stopPropagation ??= () => {
+            evt._stopped = true;
+        };
+        const handlers = this._listeners.get(evt?.type) || new Set();
+        try {
+            if (evt && evt.target == null) evt.target = this;
+            evt.currentTarget = this;
+        } catch (err) {
+            /* ignore read-only target/currentTarget on native events */
+        }
+        handlers.forEach((handler) => handler.call(this, evt));
+        return true;
+    }
+    postMessage(data) {
+        const handlers = this._listeners.get("message") || new Set();
+        handlers.forEach((handler) => handler({ data }));
+    }
+    getSelection() {
+        return this._selection;
+    }
 }
 
 class FakeStorage {
-  constructor() {
-    this._store = new Map();
-  }
-  getItem(key) {
-    return this._store.has(key) ? this._store.get(key) : null;
-  }
-  setItem(key, value) {
-    this._store.set(key, String(value));
-  }
-  removeItem(key) {
-    this._store.delete(key);
-  }
-  clear() {
-    this._store.clear();
-  }
+    constructor() {
+        this._store = new Map();
+    }
+    getItem(key) {
+        return this._store.has(key) ? this._store.get(key) : null;
+    }
+    setItem(key, value) {
+        this._store.set(key, String(value));
+    }
+    removeItem(key) {
+        this._store.delete(key);
+    }
+    clear() {
+        this._store.clear();
+    }
 }
 
 const voidTags = new Set([
-  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
-  'link', 'meta', 'param', 'source', 'track', 'wbr'
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
 ]);
 
 const parseAttributes = (raw) => {
-  const attrs = {};
-  if (!raw) return attrs;
-  const regex = /([^\s=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-  let match;
-  while ((match = regex.exec(raw))) {
-    const name = match[1];
-    const value = match[2] ?? match[3] ?? match[4] ?? '';
-    attrs[name] = value;
-  }
-  return attrs;
+    const attrs = {};
+    if (!raw) return attrs;
+    const regex =
+        /([^\s=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+    let match;
+    while ((match = regex.exec(raw))) {
+        const name = match[1];
+        const value = match[2] ?? match[3] ?? match[4] ?? "";
+        attrs[name] = value;
+    }
+    return attrs;
 };
 
 const extractBodyHtml = (html) => {
-  const match = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-  return match ? match[1] : html;
+    const match = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+    return match ? match[1] : html;
 };
 
 const findCallerFile = () => {
-  const stack = new Error().stack?.split('\n').slice(2) || [];
-  for (const line of stack) {
-    if (line.includes('node:internal') || line.includes('node:fs')) continue;
-    if (line.includes('pfusch-stubs.js')) continue;
-    const urlMatch = line.match(/\((file:\/\/[^)]+)\)/) || line.match(/at (file:\/\/\S+)/);
-    if (urlMatch) return fileURLToPath(urlMatch[1]);
-    const pathMatch = line.match(/\((\/[^)]+):\d+:\d+\)/) || line.match(/at (\/\S+):\d+:\d+/);
-    if (pathMatch) return pathMatch[1];
-  }
-  return null;
+    const stack = new Error().stack?.split("\n").slice(2) || [];
+    for (const line of stack) {
+        if (line.includes("node:internal") || line.includes("node:fs"))
+            continue;
+        if (line.includes("pfusch-stubs.js")) continue;
+        const urlMatch =
+            line.match(/\((file:\/\/[^)]+)\)/) ||
+            line.match(/at (file:\/\/\S+)/);
+        if (urlMatch) return fileURLToPath(urlMatch[1]);
+        const pathMatch =
+            line.match(/\((\/[^)]+):\d+:\d+\)/) ||
+            line.match(/at (\/\S+):\d+:\d+/);
+        if (pathMatch) return pathMatch[1];
+    }
+    return null;
 };
 
-const PFUSCH_REMOTE_URL = new URL('https://matthiaskainer.github.io/pfusch/pfusch.js');
-const PFUSCH_CDN_RE = /(['"])(?:https:\/\/matthiaskainer\.github\.io\/pfusch\/pfusch(?:\.min)?\.js|\.\/pfusch\.js)\1/g;
+const PFUSCH_REMOTE_URL = new URL(
+    "https://matthiaskainer.github.io/pfusch/pfusch.js",
+);
+const PFUSCH_CDN_RE =
+    /(['"])(?:https:\/\/matthiaskainer\.github\.io\/pfusch\/pfusch(?:\.min)?\.js|\.\/pfusch\.js)\1/g;
 const pfuschImportCache = new Map();
 let pfuschImportEpoch = 0;
-const pfuschRemoteHash = createHash('sha1').update(PFUSCH_REMOTE_URL.href).digest('hex').slice(0, 8);
-const pfuschRemotePath = path.join(os.tmpdir(), `pfusch.remote.${pfuschRemoteHash}.js`);
+const pfuschRemoteHash = createHash("sha1")
+    .update(PFUSCH_REMOTE_URL.href)
+    .digest("hex")
+    .slice(0, 8);
+const pfuschRemotePath = path.join(
+    os.tmpdir(),
+    `pfusch.remote.${pfuschRemoteHash}.js`,
+);
 let pfuschRemotePromise = null;
 
 const ensureRemotePfusch = async () => {
-  if (pfuschRemotePromise) return pfuschRemotePromise;
-  if (fs.existsSync(pfuschRemotePath)) return pathToFileURL(pfuschRemotePath);
-  pfuschRemotePromise = (async () => {
-    if (typeof original.fetch !== 'function') {
-      throw new Error('import_for_test requires global fetch to download pfusch when no pfuschPath is provided');
-    }
-    const response = await original.fetch(PFUSCH_REMOTE_URL.href);
-    if (!response.ok) {
-      throw new Error(`import_for_test failed to download pfusch from ${PFUSCH_REMOTE_URL.href} (status ${response.status})`);
-    }
-    const source = await response.text();
-    const tempPath = `${pfuschRemotePath}.tmp`;
-    await fs.promises.writeFile(tempPath, source, 'utf8');
-    await fs.promises.rename(tempPath, pfuschRemotePath);
-    return pathToFileURL(pfuschRemotePath);
-  })().catch(err => {
-    pfuschRemotePromise = null;
-    throw err;
-  });
-  return pfuschRemotePromise;
+    if (pfuschRemotePromise) return pfuschRemotePromise;
+    if (fs.existsSync(pfuschRemotePath)) return pathToFileURL(pfuschRemotePath);
+    pfuschRemotePromise = (async () => {
+        if (typeof original.fetch !== "function") {
+            throw new Error(
+                "import_for_test requires global fetch to download pfusch when no pfuschPath is provided",
+            );
+        }
+        const response = await original.fetch(PFUSCH_REMOTE_URL.href);
+        if (!response.ok) {
+            throw new Error(
+                `import_for_test failed to download pfusch from ${PFUSCH_REMOTE_URL.href} (status ${response.status})`,
+            );
+        }
+        const source = await response.text();
+        const tempPath = `${pfuschRemotePath}.tmp`;
+        await fs.promises.writeFile(tempPath, source, "utf8");
+        await fs.promises.rename(tempPath, pfuschRemotePath);
+        return pathToFileURL(pfuschRemotePath);
+    })().catch((err) => {
+        pfuschRemotePromise = null;
+        throw err;
+    });
+    return pfuschRemotePromise;
 };
 
 const resolveFileUrl = (specifier, parentFilePath) => {
-  if (specifier instanceof URL) return specifier;
-  if (typeof specifier !== 'string') {
-    throw new Error('import_for_test expects a file path string or URL');
-  }
-  if (/^[a-zA-Z]+:/.test(specifier)) return new URL(specifier);
-  if (path.isAbsolute(specifier)) return pathToFileURL(specifier);
-  if (parentFilePath) {
-    return pathToFileURL(path.resolve(path.dirname(parentFilePath), specifier));
-  }
-  return pathToFileURL(path.resolve(process.cwd(), specifier));
+    if (specifier instanceof URL) return specifier;
+    if (typeof specifier !== "string") {
+        throw new Error("import_for_test expects a file path string or URL");
+    }
+    if (/^[a-zA-Z]+:/.test(specifier)) return new URL(specifier);
+    if (path.isAbsolute(specifier)) return pathToFileURL(specifier);
+    if (parentFilePath) {
+        return pathToFileURL(
+            path.resolve(path.dirname(parentFilePath), specifier),
+        );
+    }
+    return pathToFileURL(path.resolve(process.cwd(), specifier));
 };
 
 const resolveHtmlPath = (filePath) => {
-  if (filePath instanceof URL) return fileURLToPath(filePath);
-  if (typeof filePath !== 'string') {
-    throw new Error('loadBaseDocument expects a file path string or URL');
-  }
-  if (path.isAbsolute(filePath)) return filePath;
-  const caller = findCallerFile();
-  if (caller) {
-    const callerPath = path.resolve(path.dirname(caller), filePath);
-    if (fs.existsSync(callerPath)) return callerPath;
-  }
-  const cwdPath = path.resolve(process.cwd(), filePath);
-  if (fs.existsSync(cwdPath)) return cwdPath;
-  return cwdPath;
+    if (filePath instanceof URL) return fileURLToPath(filePath);
+    if (typeof filePath !== "string") {
+        throw new Error("loadBaseDocument expects a file path string or URL");
+    }
+    if (path.isAbsolute(filePath)) return filePath;
+    const caller = findCallerFile();
+    if (caller) {
+        const callerPath = path.resolve(path.dirname(caller), filePath);
+        if (fs.existsSync(callerPath)) return callerPath;
+    }
+    const cwdPath = path.resolve(process.cwd(), filePath);
+    if (fs.existsSync(cwdPath)) return cwdPath;
+    return cwdPath;
 };
 
 const parseHtmlInto = (html, document, parent) => {
-  const tokens = html.match(/<!--[\s\S]*?-->|<\/?[a-zA-Z][^>]*>|[^<]+/g) || [];
-  const stack = [parent];
-  tokens.forEach(token => {
-    if (!token) return;
-    if (token.startsWith('<!--')) return;
-    if (token.startsWith('</')) {
-      const tag = token.slice(2, -1).trim().toLowerCase();
-      for (let i = stack.length - 1; i > 0; i -= 1) {
-        if (stack[i]?.tagName?.toLowerCase() === tag) {
-          stack.length = i;
-          break;
+    const tokens =
+        html.match(/<!--[\s\S]*?-->|<\/?[a-zA-Z][^>]*>|[^<]+/g) || [];
+    const stack = [parent];
+    tokens.forEach((token) => {
+        if (!token) return;
+        if (token.startsWith("<!--")) return;
+        if (token.startsWith("</")) {
+            const tag = token.slice(2, -1).trim().toLowerCase();
+            for (let i = stack.length - 1; i > 0; i -= 1) {
+                if (stack[i]?.tagName?.toLowerCase() === tag) {
+                    stack.length = i;
+                    break;
+                }
+            }
+            return;
         }
-      }
-      return;
-    }
-    if (token.startsWith('<')) {
-      const selfClosing = token.endsWith('/>');
-      const inner = token.slice(1, token.length - (selfClosing ? 2 : 1)).trim();
-      if (!inner) return;
-      const [tagName] = inner.split(/\s+/);
-      const attrsRaw = inner.slice(tagName.length).trim();
-      const el = document.createElement(tagName);
-      const attrs = parseAttributes(attrsRaw);
-      Object.entries(attrs).forEach(([name, value]) => {
-        el.setAttribute(name, value);
-      });
-      stack[stack.length - 1].appendChild(el);
-      if (!selfClosing && !voidTags.has(tagName.toLowerCase())) {
-        stack.push(el);
-      }
-      return;
-    }
-    if (token.trim().length === 0) return;
-    stack[stack.length - 1].appendChild(document.createTextNode(token));
-  });
+        if (token.startsWith("<")) {
+            const selfClosing = token.endsWith("/>");
+            const inner = token
+                .slice(1, token.length - (selfClosing ? 2 : 1))
+                .trim();
+            if (!inner) return;
+            const [tagName] = inner.split(/\s+/);
+            const attrsRaw = inner.slice(tagName.length).trim();
+            const el = document.createElement(tagName);
+            const attrs = parseAttributes(attrsRaw);
+            Object.entries(attrs).forEach(([name, value]) => {
+                el.setAttribute(name, value);
+            });
+            stack[stack.length - 1].appendChild(el);
+            if (!selfClosing && !voidTags.has(tagName.toLowerCase())) {
+                stack.push(el);
+            }
+            return;
+        }
+        if (token.trim().length === 0) return;
+        stack[stack.length - 1].appendChild(document.createTextNode(token));
+    });
 };
 
 const refreshPfuschLightDom = (node) => {
-  if (!node) return;
-  if (node.lightDOMChildren !== undefined && node._lightById !== undefined) {
-    node.lightDOMChildren = Array.from(node.children || []);
-    const withIds = [
-      ...node.lightDOMChildren,
-      ...node.lightDOMChildren.flatMap(child => Array.from(child.querySelectorAll?.('[id]') || []))
-    ].filter(child => child.id);
-    node._lightById = new Map(withIds.map(child => [child.id, child]));
-  }
-  if (node.childNodes) node.childNodes.forEach(child => refreshPfuschLightDom(child));
+    if (!node) return;
+    if (node.lightDOMChildren !== undefined && node._lightById !== undefined) {
+        node.lightDOMChildren = Array.from(node.children || []);
+        const withIds = [
+            ...node.lightDOMChildren,
+            ...node.lightDOMChildren.flatMap((child) =>
+                Array.from(child.querySelectorAll?.("[id]") || []),
+            ),
+        ].filter((child) => child.id);
+        node._lightById = new Map(withIds.map((child) => [child.id, child]));
+    }
+    if (node.childNodes)
+        node.childNodes.forEach((child) => refreshPfuschLightDom(child));
 };
 
 class PfuschNodeCollection {
-  constructor(nodes = [], host = null) {
-    this.nodes = nodes.filter(Boolean);
-    this.host = host;
-  }
-  _firstNode() {
-    return this.nodes[0] || null;
-  }
-  get length() {
-    return this.nodes.length;
-  }
-  get first() {
-    const node = this._firstNode();
-    return new PfuschNodeCollection(node ? [node] : [], this.host);
-  }
-  at(index) {
-    return new PfuschNodeCollection([this.nodes[index]], this.host);
-  }
-  get state() {
-    return this.host?.state;
-  }
-  get shadowRoot() {
-    return this.host?.shadowRoot || null;
-  }
-  get value() {
-    return this._firstNode()?.value;
-  }
-  set value(val) {
-    const node = this._firstNode();
-    if (node) node.value = val;
-  }
-  get checked() {
-    return !!this._firstNode()?.checked;
-  }
-  set checked(val) {
-    const node = this._firstNode();
-    if (node) node.checked = !!val;
-  }
-  get textContent() {
-    return this._firstNode()?.textContent || '';
-  }
-  set textContent(val) {
-    const node = this._firstNode();
-    if (node) node.textContent = val;
-  }
-  submit() {
-    this._firstNode()?.submit?.();
-    return this;
-  }
-  click() {
-    this._firstNode()?.click?.();
-    return this;
-  }
-  get(selector) {
-    const matches = [];
-    this.nodes.forEach(node => {
-      const scopes = [];
-      if (node.shadowRoot) scopes.push(node.shadowRoot);
-      scopes.push(node);
-      scopes.forEach(scope => {
-        if (scope?.querySelectorAll) {
-          matches.push(...scope.querySelectorAll(selector));
-        }
-      });
-    });
-    return new PfuschNodeCollection(matches, this.host);
-  }
-  map(fn) {
-    return this.nodes.map(node => fn(new PfuschNodeCollection([node], this.host)));
-  }
-  toArray() {
-    return [...this.nodes];
-  }
-  get elements() {
-    return this.nodes;
-  }
-  async flush() {
-    await flushEffects();
-    return this;
-  }
+    constructor(nodes = [], host = null) {
+        this.nodes = nodes.filter(Boolean);
+        this.host = host;
+    }
+    _firstNode() {
+        return this.nodes[0] || null;
+    }
+    get length() {
+        return this.nodes.length;
+    }
+    get first() {
+        const node = this._firstNode();
+        return new PfuschNodeCollection(node ? [node] : [], this.host);
+    }
+    at(index) {
+        return new PfuschNodeCollection([this.nodes[index]], this.host);
+    }
+    get state() {
+        return this.host?.state;
+    }
+    get shadowRoot() {
+        return this.host?.shadowRoot || null;
+    }
+    get value() {
+        return this._firstNode()?.value;
+    }
+    set value(val) {
+        const node = this._firstNode();
+        if (node) node.value = val;
+    }
+    get checked() {
+        return !!this._firstNode()?.checked;
+    }
+    set checked(val) {
+        const node = this._firstNode();
+        if (node) node.checked = !!val;
+    }
+    get textContent() {
+        return this._firstNode()?.textContent || "";
+    }
+    set textContent(val) {
+        const node = this._firstNode();
+        if (node) node.textContent = val;
+    }
+    submit() {
+        this._firstNode()?.submit?.();
+        return this;
+    }
+    click() {
+        this._firstNode()?.click?.();
+        return this;
+    }
+    get(selector) {
+        const matches = [];
+        this.nodes.forEach((node) => {
+            const scopes = [];
+            if (node.shadowRoot) scopes.push(node.shadowRoot);
+            scopes.push(node);
+            scopes.forEach((scope) => {
+                if (scope?.querySelectorAll) {
+                    matches.push(...scope.querySelectorAll(selector));
+                }
+            });
+        });
+        return new PfuschNodeCollection(matches, this.host);
+    }
+    map(fn) {
+        return this.nodes.map((node) =>
+            fn(new PfuschNodeCollection([node], this.host)),
+        );
+    }
+    toArray() {
+        return [...this.nodes];
+    }
+    get elements() {
+        return this.nodes;
+    }
+    async flush() {
+        await flushEffects();
+        return this;
+    }
 }
 
 export async function flushEffects() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await new Promise(resolve => setTimeout(resolve, 0));
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 export function pfuschTest(tagName, attributes = {}) {
-  const element = document.createElement(tagName);
-  Object.entries(attributes).forEach(([key, value]) => {
-    const attrValue = typeof value === 'object' ? JSON.stringify(value) : value;
-    element.setAttribute(key, attrValue);
-  });
-  document.body.appendChild(element);
-  return new PfuschNodeCollection([element.shadowRoot || element], element);
+    const element = document.createElement(tagName);
+    Object.entries(attributes).forEach(([key, value]) => {
+        const attrValue =
+            typeof value === "object" ? JSON.stringify(value) : value;
+        element.setAttribute(key, attrValue);
+    });
+    document.body.appendChild(element);
+    return new PfuschNodeCollection([element.shadowRoot || element], element);
 }
 
-export async function import_for_test(modulePath, pfuschPathOrOptions = null, extraReplacements = []) {
-  const caller = findCallerFile();
-  const moduleUrl = resolveFileUrl(modulePath, caller);
-  if (moduleUrl.protocol !== 'file:') {
-    throw new Error('import_for_test only supports local file paths for modules');
-  }
-  const moduleFsPath = fileURLToPath(moduleUrl);
-  if (!fs.existsSync(moduleFsPath)) {
-    throw new Error(`import_for_test could not find module at ${moduleFsPath}`);
-  }
-
-  let pfuschPath = pfuschPathOrOptions;
-  let replacements = extraReplacements;
-
-  if (pfuschPathOrOptions && typeof pfuschPathOrOptions === 'object') {
-     pfuschPath = pfuschPathOrOptions.pfuschPath;
-     replacements = pfuschPathOrOptions.replacements || replacements;
-  }
-
-  let pfuschUrl;
-  if (pfuschPath == null) {
-    pfuschUrl = await ensureRemotePfusch();
-  } else {
-    pfuschUrl = resolveFileUrl(pfuschPath, caller);
-    if (pfuschUrl.protocol === 'file:' && !fs.existsSync(fileURLToPath(pfuschUrl))) {
-      pfuschUrl = resolveFileUrl(pfuschPath, moduleFsPath);
+export async function import_for_test(
+    modulePath,
+    pfuschPathOrOptions = null,
+    extraReplacements = [],
+) {
+    const caller = findCallerFile();
+    const moduleUrl = resolveFileUrl(modulePath, caller);
+    if (moduleUrl.protocol !== "file:") {
+        throw new Error(
+            "import_for_test only supports local file paths for modules",
+        );
     }
-    if (pfuschUrl.protocol !== 'file:') {
-      throw new Error('import_for_test only supports local file paths for pfusch');
+    const moduleFsPath = fileURLToPath(moduleUrl);
+    if (!fs.existsSync(moduleFsPath)) {
+        throw new Error(
+            `import_for_test could not find module at ${moduleFsPath}`,
+        );
     }
-    const pfuschFsPath = fileURLToPath(pfuschUrl);
-    if (!fs.existsSync(pfuschFsPath)) {
-      throw new Error(`import_for_test could not find pfusch at ${pfuschFsPath}`);
+
+    let pfuschPath = pfuschPathOrOptions;
+    let replacements = extraReplacements;
+
+    if (pfuschPathOrOptions && typeof pfuschPathOrOptions === "object") {
+        pfuschPath = pfuschPathOrOptions.pfuschPath;
+        replacements = pfuschPathOrOptions.replacements || replacements;
     }
-  }
 
-  const cacheKey = `${pfuschImportEpoch}::${moduleUrl.href}::${pfuschUrl.href}::${JSON.stringify(replacements)}`;
-  const cached = pfuschImportCache.get(cacheKey);
-  if (cached) return import(cached);
-
-  const source = await fs.promises.readFile(moduleFsPath, 'utf8');
-  let replaced = source.replace(PFUSCH_CDN_RE, `$1${pfuschUrl.href}$1`);
-
-  if (replacements && replacements.length > 0) {
-      for (const r of replacements) {
-          replaced = replaced.replace(r.pattern, r.replacement);
-      }
-  }
-
-  if (replaced === source) {
-    if (source.match(PFUSCH_CDN_RE)) {
-         throw new Error(`import_for_test regex failed to replace existing pfusch import in ${moduleFsPath}`);
+    let pfuschUrl;
+    if (pfuschPath == null) {
+        pfuschUrl = await ensureRemotePfusch();
+    } else {
+        pfuschUrl = resolveFileUrl(pfuschPath, caller);
+        if (
+            pfuschUrl.protocol === "file:" &&
+            !fs.existsSync(fileURLToPath(pfuschUrl))
+        ) {
+            pfuschUrl = resolveFileUrl(pfuschPath, moduleFsPath);
+        }
+        if (pfuschUrl.protocol !== "file:") {
+            throw new Error(
+                "import_for_test only supports local file paths for pfusch",
+            );
+        }
+        const pfuschFsPath = fileURLToPath(pfuschUrl);
+        if (!fs.existsSync(pfuschFsPath)) {
+            throw new Error(
+                `import_for_test could not find pfusch at ${pfuschFsPath}`,
+            );
+        }
     }
-     // Else maybe it didn't have it (but we expect it usually)
-  }
 
-  const ext = path.extname(moduleFsPath) || '.js';
-  const base = path.basename(moduleFsPath, ext);
-  const dir = path.dirname(moduleFsPath);
-  const hash = createHash('sha1').update(cacheKey).digest('hex').slice(0, 8);
-  // Keep the shim next to the original so relative imports keep working.
-  const tempPath = path.join(dir, `.${base}.pfusch-test.${hash}${ext}`);
-  await fs.promises.writeFile(tempPath, replaced, 'utf8');
+    const cacheKey = `${pfuschImportEpoch}::${moduleUrl.href}::${pfuschUrl.href}::${JSON.stringify(replacements)}`;
+    const cached = pfuschImportCache.get(cacheKey);
+    if (cached) return import(cached);
 
-  const tempUrl = pathToFileURL(tempPath).href;
-  const module = await import(tempUrl);
-  pfuschImportCache.set(cacheKey, tempUrl);
-  setTimeout(() => {
-    fs.promises.unlink(tempPath).catch(() => {});
-  }, 100);
-  return module;
+    const source = await fs.promises.readFile(moduleFsPath, "utf8");
+    let replaced = source.replace(PFUSCH_CDN_RE, `$1${pfuschUrl.href}$1`);
+
+    if (replacements && replacements.length > 0) {
+        for (const r of replacements) {
+            replaced = replaced.replace(r.pattern, r.replacement);
+        }
+    }
+
+    if (replaced === source) {
+        if (source.match(PFUSCH_CDN_RE)) {
+            throw new Error(
+                `import_for_test regex failed to replace existing pfusch import in ${moduleFsPath}`,
+            );
+        }
+        // Else maybe it didn't have it (but we expect it usually)
+    }
+
+    const ext = path.extname(moduleFsPath) || ".js";
+    const base = path.basename(moduleFsPath, ext);
+    const dir = path.dirname(moduleFsPath);
+    const hash = createHash("sha1").update(cacheKey).digest("hex").slice(0, 8);
+    // Keep the shim next to the original so relative imports keep working.
+    const tempPath = path.join(dir, `.${base}.pfusch-test.${hash}${ext}`);
+    await fs.promises.writeFile(tempPath, replaced, "utf8");
+
+    const tempUrl = pathToFileURL(tempPath).href;
+    const module = await import(tempUrl);
+    pfuschImportCache.set(cacheKey, tempUrl);
+    setTimeout(() => {
+        fs.promises.unlink(tempPath).catch(() => {});
+    }, 100);
+    return module;
 }
 
 export async function loadBaseDocument(filePath) {
-  const resolvedPath = resolveHtmlPath(filePath);
-  const html = await fs.promises.readFile(resolvedPath, 'utf8');
-  const bodyHtml = extractBodyHtml(html);
-  const doc = globalThis.document;
-  if (!doc?.body) {
-    throw new Error('loadBaseDocument requires setupDomStubs() to be called first');
-  }
-  if (Array.isArray(doc.body._childNodes)) {
-    doc.body._childNodes.forEach(child => {
-      disconnectTree(child);
-      if (child?.parentNode === doc.body) child.parentNode = null;
-    });
-    doc.body._childNodes = [];
-  }
-  suspendConnect = true;
-  try {
-    parseHtmlInto(bodyHtml, doc, doc.body);
-  } finally {
-    suspendConnect = false;
-  }
-  refreshPfuschLightDom(doc.body);
-  connectTree(doc.body);
-  return new PfuschNodeCollection([doc.body]);
+    const resolvedPath = resolveHtmlPath(filePath);
+    const html = await fs.promises.readFile(resolvedPath, "utf8");
+    const bodyHtml = extractBodyHtml(html);
+    const doc = globalThis.document;
+    if (!doc?.body) {
+        throw new Error(
+            "loadBaseDocument requires setupDomStubs() to be called first",
+        );
+    }
+    if (Array.isArray(doc.body._childNodes)) {
+        doc.body._childNodes.forEach((child) => {
+            disconnectTree(child);
+            if (child?.parentNode === doc.body) child.parentNode = null;
+        });
+        doc.body._childNodes = [];
+    }
+    suspendConnect = true;
+    try {
+        parseHtmlInto(bodyHtml, doc, doc.body);
+    } finally {
+        suspendConnect = false;
+    }
+    refreshPfuschLightDom(doc.body);
+    connectTree(doc.body);
+    return new PfuschNodeCollection([doc.body]);
 }
 
 export async function loadDocumentFromString(html) {
-  const bodyHtml = extractBodyHtml(html);
-  const doc = globalThis.document;
-  if (!doc?.body) {
-    throw new Error('loadDocumentFromString requires setupDomStubs() to be called first');
-  }
-  if (Array.isArray(doc.body._childNodes)) {
-    doc.body._childNodes.forEach(child => {
-      disconnectTree(child);
-      if (child?.parentNode === doc.body) child.parentNode = null;
-    });
-    doc.body._childNodes = [];
-  }
-  suspendConnect = true;
-  try {
-    parseHtmlInto(bodyHtml, doc, doc.body);
-  } finally {
-    suspendConnect = false;
-  }
-  refreshPfuschLightDom(doc.body);
-  connectTree(doc.body);
-  return new PfuschNodeCollection([doc.body]);
+    const bodyHtml = extractBodyHtml(html);
+    const doc = globalThis.document;
+    if (!doc?.body) {
+        throw new Error(
+            "loadDocumentFromString requires setupDomStubs() to be called first",
+        );
+    }
+    if (Array.isArray(doc.body._childNodes)) {
+        doc.body._childNodes.forEach((child) => {
+            disconnectTree(child);
+            if (child?.parentNode === doc.body) child.parentNode = null;
+        });
+        doc.body._childNodes = [];
+    }
+    suspendConnect = true;
+    try {
+        parseHtmlInto(bodyHtml, doc, doc.body);
+    } finally {
+        suspendConnect = false;
+    }
+    refreshPfuschLightDom(doc.body);
+    connectTree(doc.body);
+    return new PfuschNodeCollection([doc.body]);
 }
 
 export function setupDomStubs() {
-  // Recreate module side effects (e.g., customElements registration) for each fresh DOM sandbox.
-  pfuschImportCache.clear();
-  pfuschImportEpoch += 1;
-  const messageListeners = new Map();
-  const selection = new FakeSelection();
-  const fakeWindow = new FakeWindow(selection, messageListeners);
-  const fakeDocument = new FakeDocument(selection, messageListeners);
-  function createSimpleFetchMock({ defaultPayload = { structuredContent: null } } = {}) {
-    const calls = [];
-    const routes = []; // [{ key, payload }], newest wins
+    // Recreate module side effects (e.g., customElements registration) for each fresh DOM sandbox.
+    pfuschImportCache.clear();
+    pfuschImportEpoch += 1;
+    const messageListeners = new Map();
+    const selection = new FakeSelection();
+    const fakeWindow = new FakeWindow(selection, messageListeners);
+    const fakeDocument = new FakeDocument(selection, messageListeners);
+    function createSimpleFetchMock({
+        defaultPayload = { structuredContent: null },
+    } = {}) {
+        const calls = [];
+        const routes = []; // [{ key, payload }], newest wins
 
-    async function fetchMock(url, init) {
-      const urlStr = String(url);
-      calls.push({ url: urlStr, init, timestamp: Date.now() });
+        async function fetchMock(url, init) {
+            const urlStr = String(url);
+            calls.push({ url: urlStr, init, timestamp: Date.now() });
 
-      const hit = routes.find((r) => urlStr.includes(r.key));
-      const payload = hit ? hit.payload : defaultPayload;
+            const hit = routes.find((r) => urlStr.includes(r.key));
+            const payload = hit ? hit.payload : defaultPayload;
 
-      return {
-        ok: true,
-        json: async () => payload,
-      };
+            return {
+                ok: true,
+                json: async () => payload,
+            };
+        }
+
+        fetchMock.addRoute = (key, payload) => {
+            routes.unshift({ key, payload });
+        };
+
+        fetchMock.resetRoutes = () => {
+            routes.length = 0;
+        };
+
+        fetchMock.getCalls = () => [...calls];
+
+        fetchMock.resetCalls = () => {
+            calls.length = 0;
+        };
+
+        return fetchMock;
     }
-
-    fetchMock.addRoute = (key, payload) => {
-      routes.unshift({ key, payload });
+    globalThis.fetch = createSimpleFetchMock();
+    globalThis.window = fakeWindow;
+    globalThis.location = fakeWindow.location;
+    globalThis.document = fakeDocument;
+    fakeWindow.document = fakeDocument;
+    fakeDocument.defaultView = fakeWindow;
+    globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+    globalThis.CSSStyleSheet = class {
+        replaceSync() {}
     };
-
-    fetchMock.resetRoutes = () => {
-      routes.length = 0;
-    };
-
-    fetchMock.getCalls = () => [...calls];
-
-    fetchMock.resetCalls = () => {
-      calls.length = 0;
-    };
-
-    return fetchMock;
-  }
-  globalThis.fetch = createSimpleFetchMock();
-  globalThis.window = fakeWindow;
-  globalThis.location = fakeWindow.location;
-  globalThis.document = fakeDocument;
-  fakeWindow.document = fakeDocument;
-  fakeDocument.defaultView = fakeWindow;
-  globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
-  globalThis.CSSStyleSheet = class {
-    replaceSync() { }
-  };
-  globalThis.HTMLElement = FakeElement;
-  globalThis.KeyboardEvent = class KeyboardEvent {
+    globalThis.HTMLElement = FakeElement;
+    globalThis.KeyboardEvent = class KeyboardEvent {
         constructor(type, options) {
             this.type = type;
-            this.key = options?.key || '';
+            this.key = options?.key || "";
             this.ctrlKey = options?.ctrlKey || false;
             this.metaKey = options?.metaKey || false;
             this.bubbles = options?.bubbles || false;
             this.cancelable = options?.cancelable || false;
             this._preventDefault = false;
         }
-        preventDefault() { this._preventDefault = true; }
+        preventDefault() {
+            this._preventDefault = true;
+        }
     };
-  globalThis.matchMedia = () => ({
-      matches: false,
-      addListener: () => { },
-      removeListener: () => { },
-  });
-  globalThis.localStorage = new FakeStorage();
-  globalThis.sessionStorage = new FakeStorage();
-  globalThis.customElements = {
-    _registry: new Map(),
-    define(name, ctor) {
-      this._registry.set(name, ctor);
-    },
-    get(name) {
-      return this._registry.get(name);
-    }
-  };
-  globalThis.FormData = FakeFormData;
-  globalThis.CustomEvent = FakeCustomEvent;
-  globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
-  globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
-  globalThis.MutationObserver = FakeMutationObserver;
-  globalThis.triggerMutation = triggerMutation;
-  return {
-    window: fakeWindow,
-    document: fakeDocument,
-    selection,
-    restore() {
-      globalThis.window = original.window || fakeWindow;
-      globalThis.document = original.document || fakeDocument;
-      globalThis.Node = original.Node || globalThis.Node;
-      globalThis.CSSStyleSheet = original.CSSStyleSheet || globalThis.CSSStyleSheet;
-      globalThis.customElements = original.customElements || globalThis.customElements;
-      globalThis.HTMLElement = original.HTMLElement || globalThis.HTMLElement;
-      globalThis.FormData = original.FormData || globalThis.FormData;
-      globalThis.CustomEvent = original.CustomEvent || globalThis.CustomEvent;
-      globalThis.requestAnimationFrame = original.requestAnimationFrame || globalThis.requestAnimationFrame;
-      globalThis.cancelAnimationFrame = original.cancelAnimationFrame || globalThis.cancelAnimationFrame;
-      globalThis.fetch = original.fetch || globalThis.fetch;
-      globalThis.KeyboardEvent = original.KeyboardEvent || globalThis.KeyboardEvent;
-      globalThis.localStorage = original.localStorage || globalThis.localStorage;
-      globalThis.sessionStorage = original.sessionStorage || globalThis.sessionStorage;
-      globalThis.matchMedia = original.matchMedia || globalThis.matchMedia;
-      globalThis.MutationObserver = original.MutationObserver || globalThis.MutationObserver;
-      globalThis.triggerMutation = undefined;
-    }
-  };
+    globalThis.matchMedia = () => ({
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+    });
+    globalThis.localStorage = new FakeStorage();
+    globalThis.sessionStorage = new FakeStorage();
+    globalThis.customElements = {
+        _registry: new Map(),
+        define(name, ctor) {
+            this._registry.set(name, ctor);
+        },
+        get(name) {
+            return this._registry.get(name);
+        },
+    };
+    globalThis.FormData = FakeFormData;
+    globalThis.CustomEvent = FakeCustomEvent;
+    globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+    globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+    globalThis.MutationObserver = FakeMutationObserver;
+    globalThis.triggerMutation = triggerMutation;
+    return {
+        window: fakeWindow,
+        document: fakeDocument,
+        selection,
+        restore() {
+            globalThis.window = original.window || fakeWindow;
+            globalThis.document = original.document || fakeDocument;
+            globalThis.Node = original.Node || globalThis.Node;
+            globalThis.CSSStyleSheet =
+                original.CSSStyleSheet || globalThis.CSSStyleSheet;
+            globalThis.customElements =
+                original.customElements || globalThis.customElements;
+            globalThis.HTMLElement =
+                original.HTMLElement || globalThis.HTMLElement;
+            globalThis.FormData = original.FormData || globalThis.FormData;
+            globalThis.CustomEvent =
+                original.CustomEvent || globalThis.CustomEvent;
+            globalThis.requestAnimationFrame =
+                original.requestAnimationFrame ||
+                globalThis.requestAnimationFrame;
+            globalThis.cancelAnimationFrame =
+                original.cancelAnimationFrame ||
+                globalThis.cancelAnimationFrame;
+            globalThis.fetch = original.fetch || globalThis.fetch;
+            globalThis.KeyboardEvent =
+                original.KeyboardEvent || globalThis.KeyboardEvent;
+            globalThis.localStorage =
+                original.localStorage || globalThis.localStorage;
+            globalThis.sessionStorage =
+                original.sessionStorage || globalThis.sessionStorage;
+            globalThis.matchMedia =
+                original.matchMedia || globalThis.matchMedia;
+            globalThis.MutationObserver =
+                original.MutationObserver || globalThis.MutationObserver;
+            globalThis.triggerMutation = undefined;
+        },
+    };
 }

--- a/app/app_facade/node_test_helpers/pfusch.js
+++ b/app/app_facade/node_test_helpers/pfusch.js
@@ -1,1 +1,170 @@
-const t="string",e="object",s=JSON.stringify,i=new Map,n=["checked","selected","disabled","readonly","multiple"],r=e=>{try{return e&&typeof e===t?JSON.parse(e):e}catch{return e}},o=(e,...s)=>typeof e===t?e:e.reduce((t,e,i)=>t+e+(s[i]||""),"");export const css=(t,...e)=>{const s=o(t,...e);let n;return{type:"style",content:()=>n||(n=i.get(s)||(i.set(s,n=new CSSStyleSheet),n.replaceSync(s),n))}};export const script=t=>({type:"script",content:t});export const toElem=t=>t instanceof a?t:"undefined"!=typeof HTMLElement&&t instanceof HTMLElement?{element:t}:3===t?.nodeType?t.textContent:t;class a{constructor(t,...e){this.element=document.createElement(t),this.state=e[0]||{},e.forEach((t,s)=>this.add(t,()=>e.slice(s+1)))}add(t,i=()=>[]){if(!t)return this;const n=typeof t;var r;return"string"===n?this.element.appendChild(document.createTextNode(t)):Array.isArray(t)?t.forEach(t=>this.add(t,i)):t.raw?this.element.innerHTML=o(t,...i()):t.element||t instanceof HTMLElement?this.element.appendChild(t.element||t):n===e&&Object.entries(t).forEach((r=this.element,([t,i])=>{+t!=t&&("function"==typeof i?(r._re??={},r._re[t]&&r.removeEventListener(t,r._re[t]),r.addEventListener(t,r._re[t]=i)):typeof i===e&&r.state?r.state[t]=i:t in r?r[t]=i:r.setAttribute(t,typeof i===e?s(i):i))})),this}}export const html=new Proxy({},{get:(t,i)=>(...t)=>{if("raw"===i)return t=>({element:Object.assign(document.createElement("span"),{innerHTML:t})});if(i.includes("-")||customElements.get(i)){const n=document.createElement(i),[r,...o]=t[0]&&typeof t[0]===e&&!Array.isArray(t[0])?t:[{},...t];return Object.entries(r).forEach(([t,i])=>n["function"==typeof i?"addEventListener":"setAttribute"](t,typeof i===e?s(i):i)),o.forEach(t=>n.appendChild("string"==typeof t?document.createTextNode(t):t?.element||t)),{element:n}}return new a(i,...t)}});export function pfusch(t,e,i){i||([i,e]=[e,{}]);class o extends HTMLElement{static formAssociated=!0;static observedAttributes=["id","as","inject-styles","inject-links",...Object.keys(e).flatMap(t=>[t,t.toLowerCase()])];#t;constructor(){super(),this.#t=this.attachInternals(),this._f=32,this._subs={},this._ids=new Map,this.is={...e};for(const[t]of Object.entries(e)){const e=this.getAttribute(t)||this.getAttribute(t.toLowerCase());null!==e&&(this.is[t]=r(e))}this.lightDOMChildren=Array.from(this.children),this._hydrating=!0,this._lightById=new Map([...this.lightDOMChildren,...this.lightDOMChildren.flatMap(t=>Array.from(t.querySelectorAll?.("[id]")||[]))].filter(t=>t.id).map(t=>[t.id,t])),this.attachShadow({mode:"open",serializable:!0}),this.state=new Proxy({...this.is},{set:(t,e,i)=>(t[e]!==i&&(t[e]=i,"subscribe"===e||32&this._f||(this.scheduleRender(),this.#t.setFormValue(s(t))),(this._subs[e]||[]).forEach(t=>t(i))),!0),get:(t,e)=>"subscribe"===e?(e,s)=>{(this._subs[e]??=[]).push(s);try{s(t[e])}catch{}return()=>{const t=this._subs[e];t&&(this._subs[e]=t.filter(t=>t!==s))}}:t[e]})}connectedCallback(){32&this._f&&(this._f&=-33,"lazy"===this.getAttribute("as")&&this.shadowRoot.children.length||this.render())}disconnectedCallback(){this.dispatchEvent(new CustomEvent("disconnected",{bubbles:!1}))}getStableId(t,e){const s=`${t}-${e}`;return this._ids.has(s)||this._ids.set(s,`${t.toLowerCase()}-${Math.random().toString(36).substring(2,8)}`),this._ids.get(s)}attributeChangedCallback(t,e,s){if(e===s)return;if("as"===t&&"lazy"!==s&&"lazy"===e)return this.render();const i=Object.keys(this.is).find(e=>e===t||e.toLowerCase()===t);i&&this.state&&(this.state[i]=r(s))}render(){if(!i)return;if(8&this._f)return void(this._f|=16);this._f|=8;const e=t=>t?this.lightDOMChildren.filter(e=>e.tagName?.toLowerCase()===t.toLowerCase()||e.matches?.(t)):this.lightDOMChildren,n=i(this.state,(e,i)=>{const n=`${t}.${e}`;[n,e].forEach(t=>this.dispatchEvent(new CustomEvent(t,{detail:i,bubbles:!0,composed:!0}))),window.postMessage({eventName:n,detail:{sourceId:this.is.id,data:s(i)}},"*")},{children:e,childElements:t=>e(t).map(toElem)});if(!Array.isArray(n))return;const r=this.shadowRoot.activeElement?.id;if(!(2&this._f)){const t=[...document.querySelectorAll(this.getAttribute("inject-styles")||"style[data-pfusch]")];if(t.length){const e=new CSSStyleSheet;e.replaceSync(t.map(t=>t.textContent||t.innerHTML).join("\n")),this.shadowRoot.adoptedStyleSheets=[e,...this.shadowRoot.adoptedStyleSheets]}this._f|=2}4&this._f||(document.querySelectorAll(this.getAttribute("inject-links")||"link[data-pfusch]").forEach(t=>this.shadowRoot.appendChild(t.cloneNode(!0))),this._f|=4);const o=[];this._pos=0;const h=t=>{const e=t.id&&this._lightById?.get(t.id);if(e&&e.tagName===t.tagName){const s=new Set(Array.from(t.attributes).map(t=>t.name));Array.from(e.attributes).forEach(e=>{s.has(e.name)||t.setAttribute(e.name,e.value)}),e.classList.forEach(e=>t.classList.add(e)),(e instanceof HTMLInputElement||e instanceof HTMLTextAreaElement)&&!t.hasAttribute("value")&&e.value&&!t.value&&(t.value=e.value)}t.querySelectorAll?.("[id]").forEach(h)},l=t=>{t.id||(t.id=this.getStableId(t.tagName,this._pos++)),h(t),o.push(t)},c=t=>{if(!t)return;const e=t?.element||((s=t)&&(s instanceof a||"undefined"!=typeof window&&window.Element&&s instanceof window.Element||1===s.nodeType)?t:null);var s;if(e)l(e);else if("string"==typeof t){const e=document.createElement("span");e.textContent=t,l(e)}};n.forEach(t=>{if(t)if("style"===t.type){const e=t.content();this.shadowRoot.adoptedStyleSheets.includes(e)||(this.shadowRoot.adoptedStyleSheets=[...this.shadowRoot.adoptedStyleSheets,e])}else if("script"!==t.type||1&this._f)Array.isArray(t)?t.forEach(c):c(t);else{try{t.content.call({component:this,shadowRoot:this.shadowRoot,state:this.state,addEventListener:this.addEventListener.bind(this),querySelector:t=>this.shadowRoot.querySelector(t),querySelectorAll:t=>this.shadowRoot.querySelectorAll(t)})}catch(t){console.error("Script error:",t)}this._f|=1}}),this.syncChildren(this.shadowRoot,o.filter(t=>"LINK"!==t.tagName)),r&&requestAnimationFrame(()=>this.shadowRoot.getElementById(r)?.focus()),this._f&=-9,this._hydrating=!1,64&this._f&&(this._f&=-65),16&this._f&&(this._f&=-17,this.render())}scheduleRender(){8&this._f?this._f|=16:64&this._f||(this._f|=64,queueMicrotask(()=>{64&this._f&&!(8&this._f)?this.render():this._f|=16}))}syncChildren(t,e){const s=Array.from(t.children).filter(t=>null===t.getAttribute("data-pfusch")),i=new Map(s.filter(t=>t.id).map(t=>[t.id,t])),r=new Set,o=(t,e)=>t.id||(t.id=this.getStableId(t.tagName,e)),a=(t,e)=>{if(!e._re&&!t._re)return;t._re??={};const s=e._re||{};for(const[e,i]of Object.entries(s))t._re[e]!==i&&(t._re[e]&&t.removeEventListener(e,t._re[e]),t.addEventListener(e,t._re[e]=i));for(const e of Object.keys(t._re))s[e]||(t.removeEventListener(e,t._re[e]),delete t._re[e])},h=(t,e)=>{const s=new Set;for(const i of e.attributes)"id"!==i.name&&(s.add(i.name),t.getAttribute(i.name)!==i.value&&t.setAttribute(i.name,i.value));for(const e of Array.from(t.attributes))"id"===e.name||s.has(e.name)||t.removeAttribute(e.name)},l=(t,e)=>{if(n.forEach(s=>{if(void 0!==e[s]&&e[s]!==t[s])try{t[s]=e[s]}catch{}}),"value"in e&&!(/^(INPUT|TEXTAREA|SELECT)$/.test(e.tagName)&&!e.hasAttribute?.("value")||document.activeElement===t||t.contains(document.activeElement))&&e.value!==t.value)try{t.value=e.value}catch{}},c=(t,e)=>{const s=Array.from(e.childNodes);if(!s.length)return void(t.firstChild&&(t.textContent=""));const i=[],n=new Map,r=new Map;for(const e of Array.from(t.childNodes))if(3===e.nodeType)i.push(e);else if(1===e.nodeType)if(e.id)n.set(e.id,e);else{const t=r.get(e.tagName)||[];t.push(e),r.set(e.tagName,t)}let a=null,h=0;const l=e=>{a?a.nextSibling!==e&&t.insertBefore(e,a.nextSibling):t.firstChild!==e&&t.insertBefore(e,t.firstChild),a=e};s.forEach(t=>{if(3===t.nodeType){const e=i.shift(),s=e||document.createTextNode(t.textContent);return e&&e.textContent!==t.textContent&&(e.textContent=t.textContent),void l(s)}if(1===t.nodeType){o(t,h++);let e=n.get(t.id);if(e)n.delete(t.id);else{const s=r.get(t.tagName);s?.length&&(e=s.shift())}l(e?d(e,t):t)}}),[i,...n.values(),...[...r.values()].flat()].flat().forEach(e=>{e?.parentNode===t&&e.remove()})},d=(t,e)=>t.tagName!==e.tagName?(t.replaceWith(e),e):([a,h,l,c].forEach(s=>s(t,e)),t),f=e.map((e,s)=>{const n=o(e,s),a=i.get(n);a&&i.delete(n);const h=a?d(a,e):t.appendChild(e);return r.add(h.id),h});s.forEach(t=>{r.has(t.id)||t.remove()});let u=null;for(const e of f)e.parentNode&&((u?u.nextElementSibling!==e:t.firstElementChild!==e)&&t.insertBefore(e,u?.nextElementSibling||t.firstElementChild),u=e)}}return customElements.define(t,o),o}
+const s = 'string', o = 'object', jstr = JSON.stringify, cssCache = new Map();
+// Standard HTML boolean attributes: a boolean value here means presence/absence, not the string "true"/"false".
+// This deliberately excludes aria-* (aria-hidden, aria-expanded, ...), which require the literal string.
+const boolAttrs = ['checked', 'selected', 'disabled', 'readonly', 'multiple', 'hidden', 'required', 'autofocus', 'open', 'inert'], boolAttrSet = new Set(boolAttrs);
+const json = j => { try { return j && typeof j === s ? JSON.parse(j) : j; } catch { return j; } };
+const str = (string, ...tags) => typeof string === s ? string : string.reduce((acc, part, i) => acc + part + (tags[i] || ''), '');
+const isEl = n => n && (n.nodeType === 1 || (typeof window !== 'undefined' && window.Element && n instanceof window.Element));
+const isBoolAttrValue = (key, value) => boolAttrSet.has(key) && typeof value === 'boolean';
+// _f bitflags (kept as a single field to stay small after minification):
+const SCRIPTS_EXEC = 1, STYLES_INJECTED = 2, LINKS_CLONED = 4, RENDERING = 8, NEEDS_RERENDER = 16, INIT = 32, QUEUED = 64;
+const attrNames = k => [k, k.toLowerCase(), k.replace(/[A-Z]/g, "-$&").toLowerCase()];
+
+// cssCache is unbounded and keyed by the rendered CSS text — fine for the intended use (static css`` templates
+// shared across instances), but avoid interpolating per-instance/dynamic values into a css`` template.
+export const css = (style, ...tags) => {
+    const cssText = str(style, ...tags);
+    let sheet;
+    const content = () => {
+        if (sheet) return sheet;
+        sheet = cssCache.get(cssText);
+        if (!sheet) { sheet = new CSSStyleSheet(); sheet.replaceSync(cssText); cssCache.set(cssText, sheet); }
+        return sheet;
+    };
+    return { type: 'style', content };
+};
+export const script = js => ({ type: 'script', content: js });
+
+// Descriptor: { _t: tag, _a: attrs, _c: children, _re: handlers } — no real DOM nodes until sync
+class Element {
+    constructor(tag, ...rest) { this._t = tag; this._a = {}; this._c = []; this._re = {}; rest.forEach((item, i) => this.add(item, () => rest.slice(i + 1))); }
+    get element() {
+        const a = this._a, s = this;
+        const cl = { add: (...c) => { a.class = [...new Set([...(a.class?.split(' ') || []), ...c])].filter(Boolean).join(' '); }, remove: (...c) => { const r = new Set(c); a.class = (a.class?.split(' ') || []).filter(x => !r.has(x)).join(' '); }, contains: c => (a.class?.split(' ') || []).includes(c), toggle: (c, f) => { const has = cl.contains(c); (f ?? !has) ? cl.add(c) : cl.remove(c); } };
+        return new Proxy(a, { get(_, k) { return k === 'innerHTML' ? (s._html || '') : k === 'setAttribute' ? (n, v) => { a[n] = v; } : k === 'getAttribute' ? (n) => a[n] != null ? String(a[n]) : null : k === 'removeAttribute' ? (n) => { delete a[n]; } : k === 'hasAttribute' ? (n) => n in a : k === 'classList' ? cl : a[k]; }, set(_, k, v) { if (k === 'innerHTML') s._html = v; else a[k] = v; return true; } });
+    }
+    add(option, ah = () => []) {
+        if (!option) return this;
+        const t = typeof option;
+        if (t === 'string') this._c.push(option);
+        else if (Array.isArray(option)) option.forEach(c => this.add(c, ah));
+        else if (option.raw) this._html = str(option, ...ah());
+        else if (option._t || option.element || option instanceof HTMLElement) this._c.push(option);
+        else if (t === o) Object.entries(option).forEach(([k, v]) => { if (+k == k) return; if (typeof v === 'function') this._re[k] = v; else this._a[k] = v; });
+        return this;
+    }
+}
+
+const toElem = node => node?._t ? node : (typeof HTMLElement !== 'undefined' && node instanceof HTMLElement) ? { element: node } : node?.nodeType === 3 ? node.textContent : node;
+export const toElement = (desc) => { const el = document.createElement(desc._t); for (const [k, v] of Object.entries(desc._a)) if (typeof v !== 'function' && v != null) { if (isBoolAttrValue(k, v)) { if (v) el.setAttribute(k, 'true'); } else el.setAttribute(k, typeof v === o ? jstr(v) : String(v)); } for (const [k, h] of Object.entries(desc._re)) { el._re ??= {}; el.addEventListener(k, el._re[k] = h); } if (desc._html !== undefined) { el.innerHTML = desc._html; return el; } for (const c of desc._c) el.appendChild(typeof c === 'string' ? document.createTextNode(c) : c._t ? toElement(c) : c.element || c); return el; };
+
+export const html = new Proxy({}, { get: (_, key) => key === 'raw' ? (content, ...tags) => ({ _t: 'span', _a: {}, _c: [], _re: {}, _html: str(content, ...tags) }) : (...args) => new Element(key, ...args) });
+
+export function pfusch(tagName, initialState, template) {
+    if (!template) [template, initialState] = [initialState, {}];
+    const attrMap = Object.fromEntries(Object.keys(initialState).flatMap(k => attrNames(k).map(n => [n, k])));
+    const boolStateKeys = new Set(Object.entries(initialState).filter(([, v]) => typeof v === 'boolean').map(([k]) => k));
+    const toStateValue = (key, rawValue) => {
+        if (!boolStateKeys.has(key)) return json(rawValue);
+        if (rawValue === null) return false;
+        if (rawValue === '') return true;
+        const parsed = json(rawValue);
+        return typeof parsed === 'boolean' ? parsed : Boolean(parsed);
+    };
+
+    class Pfusch extends HTMLElement {
+        static formAssociated = true;
+        static observedAttributes = ["id", "as", "inject-styles", "inject-links", ...Object.keys(initialState).flatMap(attrNames)];
+        #internals;
+
+        get internals() { return this.#internals; }
+
+        constructor() {
+            super();
+            this.#internals = this.attachInternals();
+            this._f = INIT; this._subs = {};
+            this._disconnectPending = false;
+            this.lightDOMChildren = Array.from(this.children);
+            this._lightById = new Map([...this.lightDOMChildren, ...this.lightDOMChildren.flatMap(c => Array.from(c.querySelectorAll?.('[id]') || []))].filter(c => c.id).map(c => [c.id, c]));
+            this._lightDomRetryDone = false;
+            this.attachShadow({ mode: 'open', serializable: true });
+            this._raw = { ...initialState };
+            for (const k of Object.keys(initialState)) { let v = null; for (const attrName of attrNames(k)) if ((v = this.getAttribute(attrName)) !== null) break; if (v !== null) this._raw[k] = toStateValue(k, v); }
+            this.state = new Proxy(this._raw, {
+                set: (target, key, value) => { if (target[key] !== value) { if (key !== "subscribe" && !(key in target)) console.warn(`pfusch: <${tagName}> set state.${key}, which isn't in initialState — check for a typo`); target[key] = value; if (key !== "subscribe" && !(this._f & INIT)) { this.scheduleRender(); } (this._subs[key] || []).forEach(cb => cb(value)); } return true; },
+                get: (target, key) => key === 'subscribe' ? (prop, cb) => { (this._subs[prop] ??= []).push(cb); try { cb(target[prop]); } catch { } return () => { const a = this._subs[prop]; if (a) this._subs[prop] = a.filter(f => f !== cb); }; } : target[key]
+            });
+        }
+
+        connectedCallback() { this._disconnectPending = false; if (this._f & INIT) { this._f &= ~INIT; if (this.getAttribute('as') !== 'lazy' || !this.shadowRoot.children.length) this.render(); } }
+        disconnectedCallback() { this._disconnectPending = true; queueMicrotask(() => { if (!this._disconnectPending || this.isConnected) return; this._disconnectPending = false; this.dispatchEvent(new CustomEvent('disconnected', { bubbles: false }));}); }
+        getStableId(tag, pos) { return `${tag.toLowerCase()}-${pos}`; }
+
+        attributeChangedCallback(name, oldValue, newValue) { if (oldValue === newValue) return; if (name === 'as' && newValue !== 'lazy' && oldValue === 'lazy') return this.render(); const key = attrMap[name]; if (key && this.state) this.state[key] = toStateValue(key, newValue); }
+
+        render(force = false) {
+            if (!template) return;
+            if (this._f & RENDERING) { this._f |= NEEDS_RERENDER; return; }
+            const snap = jstr(this._raw);
+            if (!force && snap === this._snap) { this._f &= ~(QUEUED|NEEDS_RERENDER); return; }
+            this._f |= RENDERING;
+            if (!this.lightDOMChildren.length) this.lightDOMChildren = Array.from(this.children), this._lightById = new Map([...this.lightDOMChildren, ...this.lightDOMChildren.flatMap(c => Array.from(c.querySelectorAll?.('[id]') || []))].filter(c => c.id).map(c => [c.id, c]));
+            const trigger = (eventName, detail) => { const full = `${tagName}.${eventName}`;[full, eventName].forEach(e => this.dispatchEvent(new CustomEvent(e, { detail, bubbles: true, composed: true }))); let data; try { data = jstr(detail); } catch { data = null; } window.postMessage({ eventName: full, detail: { sourceId: this.id, data } }, "*"); };
+            const children = sel => sel ? this.lightDOMChildren.filter(c => c.tagName?.toLowerCase() === sel.toLowerCase() || c.matches?.(sel)) : this.lightDOMChildren;
+            const result = template(this.state, trigger, { children, childElements: s => children(s).map(toElem) });
+            if (!Array.isArray(result)) return;
+            const hasSlot = n => !!n && (n._t === 'slot' || Array.isArray(n) && n.some(hasSlot) || n._c?.some(hasSlot));
+            const focusId = this.shadowRoot.activeElement?.id;
+
+            if (!(this._f & STYLES_INJECTED)) { const gs = [...document.querySelectorAll(this.getAttribute("inject-styles") || "style[data-pfusch]")]; if (gs.length) { const sh = new CSSStyleSheet(); sh.replaceSync(gs.map(g => g.textContent || g.innerHTML).join("\n")); this.shadowRoot.adoptedStyleSheets = [sh, ...this.shadowRoot.adoptedStyleSheets]; } this._f |= STYLES_INJECTED; } // inject global styles once
+            if (!(this._f & LINKS_CLONED)) { document.querySelectorAll(this.getAttribute("inject-links") || "link[data-pfusch]").forEach(l => this.shadowRoot.appendChild(l.cloneNode(true))); this._f |= LINKS_CLONED; }
+
+            const elementItems = []; this._pos = 0;
+            const mergeFromOriginal = (desc) => { const orig = desc._a.id && this._lightById?.get(desc._a.id); if (orig && orig.tagName.toLowerCase() === desc._t) { const tplKeys = new Set(Object.keys(desc._a)); Array.from(orig.attributes).forEach(a => { if (!tplKeys.has(a.name)) desc._a[a.name] = a.value; }); orig.classList.forEach(cls => { if (!desc._a.class?.split(' ').includes(cls)) desc._a.class = desc._a.class ? desc._a.class + ' ' + cls : cls; }); if ((orig instanceof HTMLInputElement || orig instanceof HTMLTextAreaElement) && !('value' in desc._a) && orig.value) desc._a.value = orig.value; } desc._c?.forEach(c => c?._t && mergeFromOriginal(c)); };
+            const pushEl = desc => { if (!desc._a.id) desc._a.id = this.getStableId(desc._t, this._pos++); if (this._lightById.size) mergeFromOriginal(desc); elementItems.push(desc); };
+            const processItem = i => { if (!i) return; if (i._t) { pushEl(i); return; } const el = i.element || (isEl(i) ? i : null); if (el) { if (!el.id) el.id = this.getStableId(el.tagName, this._pos++); elementItems.push({ _el: el }); } else if (typeof i === 'string') pushEl({ _t: 'span', _a: {}, _c: [i], _re: {} }); };
+
+            result.forEach(item => {
+                if (!item) return;
+                if (item.type === 'style') { const sheet = item.content(); if (!this.shadowRoot.adoptedStyleSheets.includes(sheet)) this.shadowRoot.adoptedStyleSheets = [...this.shadowRoot.adoptedStyleSheets, sheet]; }
+                else if (item.type === 'script' && !(this._f & SCRIPTS_EXEC)) { if (!this.lightDOMChildren.length && !this._lightDomRetryDone && result.some(hasSlot)) { this._lightDomRetryDone = true; setTimeout(() => { this._snap = undefined; this.render(); }); return; } try { item.content.call({ component: this, shadowRoot: this.shadowRoot, state: this.state, addEventListener: this.addEventListener.bind(this), querySelector: s => this.shadowRoot.querySelector(s), querySelectorAll: s => this.shadowRoot.querySelectorAll(s) }); } catch (e) { console.error('Script error:', e); } this._f |= SCRIPTS_EXEC; }
+                else if (Array.isArray(item)) item.forEach(processItem);
+                else processItem(item);
+            });
+
+            this.syncChildren(this.shadowRoot, elementItems.filter(e => (e._t || e._el?.tagName || '').toUpperCase() !== 'LINK'));
+            if (focusId) requestAnimationFrame(() => this.shadowRoot.getElementById(focusId)?.focus());
+            this.#internals.setFormValue(this._snap = (this._f & NEEDS_RERENDER ? jstr(this._raw) : snap));
+            this._f &= ~RENDERING; if (this._f & QUEUED) this._f &= ~QUEUED; if (this._f & NEEDS_RERENDER) { this._f &= ~NEEDS_RERENDER; this.render(true); }
+        }
+
+        scheduleRender() { if (this._f & RENDERING) { this._f |= NEEDS_RERENDER; return; } if (this._f & QUEUED) return; this._f |= QUEUED; queueMicrotask(() => { if (!(this._f & QUEUED) || (this._f & RENDERING)) { this._f |= NEEDS_RERENDER; return; } this.render(); }); }
+
+        syncChildren(parent, newChildren) {
+            const old = Array.from(parent.children).filter(c => c.getAttribute('data-pfusch') === null), byId = new Map(old.filter(n => n.id).map(n => [n.id, n])), keep = new Set();
+            const ensureId = (n, pos) => n._el ? (n._el.id || (n._el.id = this.getStableId(n._el.tagName, pos))) : (n._a.id || (n._a.id = this.getStableId(n._t, pos)));
+
+            const syncListeners = (t, src) => { if (!src._re && !t._re) return; t._re ??= {}; const inc = src._re || {}; for (const [ev, h] of Object.entries(inc)) if (t._re[ev] !== h) { if (t._re[ev]) t.removeEventListener(ev, t._re[ev]); t.addEventListener(ev, t._re[ev] = h); } for (const ev of Object.keys(t._re)) if (!inc[ev]) { t.removeEventListener(ev, t._re[ev]); delete t._re[ev]; } };
+            const syncAttrs = (t, src) => { const a = src._a || {}, seen = new Set(), n = t.tagName?.includes('-') ? k => String(k).toLowerCase() : k => String(k); for (const [k, v] of Object.entries(a)) { if (k === 'id' || typeof v === 'function') continue; const attr = n(k); if (isBoolAttrValue(k, v)) { if (v) { seen.add(attr); if (t.getAttribute(attr) !== 'true') t.setAttribute(attr, 'true'); } else if (t.hasAttribute(attr)) t.removeAttribute(attr); continue; } seen.add(attr); if (v == null) { if (t.hasAttribute(attr)) t.removeAttribute(attr); continue; } const sv = typeof v === o ? jstr(v) : String(v); if (t.getAttribute(attr) !== sv) t.setAttribute(attr, sv); } for (const at of Array.from(t.attributes)) { const attr = n(at.name); if (attr !== 'id' && !seen.has(attr)) t.removeAttribute(at.name); } };
+            const syncProps = (t, src) => { const a = src._a || {}; boolAttrs.forEach(p => { if (!(p in a) || typeof a[p] !== 'boolean') return; if (a[p] !== t[p]) try { t[p] = a[p]; } catch {} }); if ('value' in a && !(document.activeElement === t || t.contains(document.activeElement)) && String(a.value) !== t.value) try { t.value = a.value; } catch {}; };
+
+            const syncNodeChildren = (o, n) => {
+                if (n._html !== undefined) { if (o.innerHTML !== n._html) o.innerHTML = n._html; return; }
+                const newNodes = n._c || [];
+                if (!newNodes.length) { if (o.firstChild) o.textContent = ''; return; }
+                const oldNodes = Array.from(o.childNodes);
+                if (oldNodes.length === newNodes.length && oldNodes.every((c, i) => { const d = newNodes[i]; return typeof d === 'string' ? c.nodeType === 3 : c.nodeType === 1 && c.tagName === (d._t?.toUpperCase() || d.element?.tagName || d.tagName); })) {
+                    oldNodes.forEach((c, i) => { const d = newNodes[i]; typeof d === 'string' ? (c.textContent !== d && (c.textContent = d)) : d._t ? syncNode(c, d) : (c !== (d.element || d) && c.replaceWith(d.element || d)); });
+                    return;
+                }
+                const textPool = [], elemById = new Map(), elemPools = new Map();
+                for (const c of Array.from(o.childNodes))
+                    if (c.nodeType === 3) textPool.push(c); else if (c.nodeType === 1) { if (c.id) elemById.set(c.id, c); else { const p = elemPools.get(c.tagName) || []; p.push(c); elemPools.set(c.tagName, p); } }
+                let anchor = null, elIdx = 0;
+                const place = node => { if (anchor) { if (anchor.nextSibling !== node) o.insertBefore(node, anchor.nextSibling); } else if (o.firstChild !== node) o.insertBefore(node, o.firstChild); anchor = node; };
+                newNodes.forEach(d => {
+                    if (typeof d === 'string') { const r = textPool.shift(), t = r || document.createTextNode(d); if (r && r.textContent !== d) r.textContent = d; place(t); return; }
+                    if (d._t) { const tag = d._t.toUpperCase(); if (!d._a.id) d._a.id = `${d._t.toLowerCase()}-${elIdx}`; let t = elemById.get(d._a.id); if (t) elemById.delete(d._a.id); else { const p = elemPools.get(tag); if (p?.length) t = p.shift(); } place(t ? syncNode(t, d) : toElement(d)); elIdx++; }
+                    else { const el = d.element || d; place(el); }
+                });
+                [textPool, ...elemById.values(), ...[...elemPools.values()].flat()].flat().forEach(n => { if (n?.parentNode === o) n.remove(); });
+            };
+
+            const syncNode = (o, n) => { if (n._el) { if (o !== n._el) { o.replaceWith(n._el); return n._el; } return o; } if (o.tagName !== n._t?.toUpperCase()) { const m = toElement(n); o.replaceWith(m); return m; } [syncListeners, syncAttrs, syncProps, syncNodeChildren].forEach(fn => fn(o, n)); return o; };
+            const ordered = newChildren.map((n, idx) => { const id = ensureId(n, idx); const existing = byId.get(id); if (existing) byId.delete(id); const node = existing ? syncNode(existing, n) : parent.appendChild(n._el || toElement(n)); keep.add(node.id); return node; });
+            old.forEach(c => { if (!keep.has(c.id)) c.remove(); }); let anchor = null; for (const node of ordered) { if (!node.parentNode) continue; if (anchor ? anchor.nextElementSibling !== node : parent.firstElementChild !== node) parent.insertBefore(node, anchor?.nextElementSibling || parent.firstElementChild); anchor = node; }
+        }
+    }
+    customElements.define(tagName, Pfusch);
+    return Pfusch;
+}

--- a/app/app_facade/patch_ops.py
+++ b/app/app_facade/patch_ops.py
@@ -1,0 +1,355 @@
+"""Operation-based patching for conversational UI edits.
+
+Instead of asking the model to re-emit whole files inside a JSON payload
+(slow, token-hungry, and brittle because of JSON escaping), the patch
+planner returns a list of small edit operations that are applied to the
+current draft payload server-side:
+
+* ``replace`` – replace an exact ``search`` string with ``content``
+* ``append``  – append ``content`` to the end of the target
+* ``set``     – replace the whole target with ``content`` (new/small files)
+
+Application is all-or-nothing: if any operation fails, the draft stays
+untouched and the collected errors are fed back into the next patch
+attempt so the model can correct its search strings.
+"""
+
+import copy
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger("uvicorn.error")
+
+# Targets addressable by patch operations. ``html_page``/``html_snippet``
+# map into the nested ``html`` object of the payload.
+SCRIPT_TARGETS = (
+    "service_script",
+    "components_script",
+    "test_script",
+    "dummy_data",
+)
+HTML_TARGETS = ("html_page", "html_snippet")
+PATCH_TARGETS = SCRIPT_TARGETS + HTML_TARGETS
+
+PATCH_UPDATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "patch": {
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "target": {
+                                "type": "string",
+                                "enum": list(PATCH_TARGETS),
+                            },
+                            "op": {
+                                "type": "string",
+                                "enum": ["replace", "append", "set"],
+                            },
+                            "search": {
+                                "type": "string",
+                                "description": (
+                                    "Exact text copied verbatim from the current "
+                                    "target (required for op=replace)"
+                                ),
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": (
+                                    "Replacement text (replace), appended text "
+                                    "(append), or full new content (set)"
+                                ),
+                            },
+                            "replace_all": {
+                                "type": "boolean",
+                                "description": "Replace every occurrence of search (default false)",
+                            },
+                        },
+                        "required": ["target", "op", "content"],
+                        "additionalProperties": False,
+                    },
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+            "required": ["operations"],
+            "additionalProperties": False,
+        }
+    },
+    "required": ["patch"],
+    "additionalProperties": False,
+}
+
+
+def _read_target(payload: Dict[str, Any], target: str) -> Optional[str]:
+    if target in SCRIPT_TARGETS:
+        value = payload.get(target)
+    elif target == "html_page":
+        value = (payload.get("html") or {}).get("page")
+    elif target == "html_snippet":
+        value = (payload.get("html") or {}).get("snippet")
+    else:
+        return None
+    return value if isinstance(value, str) else None
+
+
+def _write_target(payload: Dict[str, Any], target: str, value: str) -> None:
+    if target in SCRIPT_TARGETS:
+        payload[target] = value
+    elif target == "html_page":
+        payload.setdefault("html", {})["page"] = value
+    elif target == "html_snippet":
+        payload.setdefault("html", {})["snippet"] = value
+
+
+def _preview(text: str, limit: int = 120) -> str:
+    text = text or ""
+    return text if len(text) <= limit else f"{text[:limit]}..."
+
+
+def legacy_patch_to_operations(patch: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert a legacy whole-file patch object into ``set`` operations."""
+    operations: List[Dict[str, Any]] = []
+    html_patch = patch.get("html")
+    if isinstance(html_patch, dict):
+        for key, target in (("page", "html_page"), ("snippet", "html_snippet")):
+            value = html_patch.get(key)
+            if isinstance(value, str) and value.strip():
+                operations.append({"target": target, "op": "set", "content": value})
+    for key in SCRIPT_TARGETS:
+        value = patch.get(key)
+        if isinstance(value, str):
+            operations.append({"target": key, "op": "set", "content": value})
+    return operations
+
+
+def apply_patch_operations(
+    payload: Dict[str, Any],
+    operations: List[Any],
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """Apply *operations* to a copy of *payload*.
+
+    Returns ``(candidate, errors)``. ``candidate`` is ``None`` when any
+    operation failed (all-or-nothing); ``errors`` then describes each
+    failure precisely enough for the model to retry with corrected input.
+    """
+    errors: List[str] = []
+    if not isinstance(operations, list) or not operations:
+        return None, ["no_operations_provided"]
+
+    candidate = copy.deepcopy(payload)
+    for index, op_raw in enumerate(operations):
+        if not isinstance(op_raw, dict):
+            errors.append(f"op[{index}]: not_an_object")
+            continue
+        target = op_raw.get("target")
+        op = op_raw.get("op")
+        content = op_raw.get("content")
+        if target not in PATCH_TARGETS:
+            errors.append(f"op[{index}]: unknown_target '{target}'")
+            continue
+        if not isinstance(content, str):
+            errors.append(f"op[{index}]: missing_content for target '{target}'")
+            continue
+
+        current = _read_target(candidate, target)
+        if op == "set":
+            _write_target(candidate, target, content)
+            continue
+        if op == "append":
+            base = current or ""
+            joined = f"{base}\n{content}" if base and not base.endswith("\n") else f"{base}{content}"
+            _write_target(candidate, target, joined)
+            continue
+        if op == "replace":
+            search = op_raw.get("search")
+            if not isinstance(search, str) or not search:
+                errors.append(
+                    f"op[{index}]: replace requires a non-empty 'search' string "
+                    f"(target '{target}')"
+                )
+                continue
+            if current is None:
+                errors.append(
+                    f"op[{index}]: target '{target}' is empty/missing; use op='set' "
+                    "to create it"
+                )
+                continue
+            occurrences = current.count(search)
+            if occurrences == 0:
+                errors.append(
+                    f"op[{index}]: search text not found in '{target}': "
+                    f"'{_preview(search)}'. Copy the text verbatim from the "
+                    "current file content."
+                )
+                continue
+            if op_raw.get("replace_all"):
+                updated = current.replace(search, content)
+            else:
+                updated = current.replace(search, content, 1)
+            _write_target(candidate, target, updated)
+            continue
+        errors.append(f"op[{index}]: unknown_op '{op}'")
+
+    if errors:
+        return None, errors
+    return candidate, []
+
+
+# ---------------------------------------------------------------------------
+# Runtime-script integrity: service_script and components_script are
+# concatenated into ONE ES module (app.js in tests, the inline module script
+# in production), so duplicate import identifiers or repeated pfusch
+# component registrations across them are fatal SyntaxErrors / silent bugs.
+# ---------------------------------------------------------------------------
+
+_IMPORT_LINE_RE = re.compile(r"^[ \t]*import\b")
+_NAMED_IMPORTS_RE = re.compile(r"\{([^}]*)\}")
+_DEFAULT_IMPORT_RE = re.compile(r"^\s*import\s+([A-Za-z_$][\w$]*)\s*(?:,|\s+from\b)")
+_NAMESPACE_IMPORT_RE = re.compile(r"\*\s*as\s+([A-Za-z_$][\w$]*)")
+_PFUSCH_REGISTRATION_RE = re.compile(r"\bpfusch\(\s*['\"]([A-Za-z][\w-]*)['\"]")
+
+
+def _import_line_identifiers(line: str) -> List[str]:
+    identifiers: List[str] = []
+    default_match = _DEFAULT_IMPORT_RE.match(line)
+    if default_match:
+        identifiers.append(default_match.group(1))
+    namespace_match = _NAMESPACE_IMPORT_RE.search(line)
+    if namespace_match:
+        identifiers.append(namespace_match.group(1))
+    named_match = _NAMED_IMPORTS_RE.search(line)
+    if named_match:
+        for part in named_match.group(1).split(","):
+            part = part.strip()
+            if not part:
+                continue
+            # `orig as alias` binds the alias
+            alias = part.split(" as ")[-1].strip()
+            if alias:
+                identifiers.append(alias)
+    return identifiers
+
+
+def _dedupe_imports_in_text(
+    text: str, declared: Set[str], seen_side_effect_imports: Set[str]
+) -> Tuple[str, List[str]]:
+    """Remove/trim import lines whose identifiers were already declared."""
+    notes: List[str] = []
+    out_lines: List[str] = []
+    for line in text.split("\n"):
+        if not _IMPORT_LINE_RE.match(line) or " from " not in f" {line} ":
+            side_effect = _IMPORT_LINE_RE.match(line) and re.search(
+                r"import\s+['\"]", line
+            )
+            if side_effect:
+                normalized = line.strip()
+                if normalized in seen_side_effect_imports:
+                    notes.append(f"dropped duplicate side-effect import: {normalized}")
+                    continue
+                seen_side_effect_imports.add(normalized)
+            out_lines.append(line)
+            continue
+
+        identifiers = _import_line_identifiers(line)
+        if not identifiers:
+            out_lines.append(line)
+            continue
+        duplicated = [name for name in identifiers if name in declared]
+        fresh = [name for name in identifiers if name not in declared]
+        declared.update(fresh)
+        if not duplicated:
+            out_lines.append(line)
+            continue
+        if not fresh:
+            notes.append(
+                f"dropped duplicate import of {{{', '.join(duplicated)}}}"
+            )
+            continue
+        named_match = _NAMED_IMPORTS_RE.search(line)
+        if named_match:
+            rewritten = (
+                line[: named_match.start()]
+                + "{ "
+                + ", ".join(fresh)
+                + " }"
+                + line[named_match.end() :]
+            )
+            notes.append(
+                f"removed already-imported {{{', '.join(duplicated)}}} from import"
+            )
+            out_lines.append(rewritten)
+        else:
+            # Cannot safely trim non-named imports; keep the line untouched.
+            out_lines.append(line)
+    return "\n".join(out_lines), notes
+
+
+def sanitize_runtime_imports(
+    service_script: str, components_script: str
+) -> Tuple[str, str, List[str]]:
+    """Drop duplicate import declarations across the concatenated runtime
+    scripts (service first, then components — the bundling order)."""
+    declared: Set[str] = set()
+    seen_side_effect: Set[str] = set()
+    sanitized_service, service_notes = _dedupe_imports_in_text(
+        service_script or "", declared, seen_side_effect
+    )
+    sanitized_components, component_notes = _dedupe_imports_in_text(
+        components_script or "", declared, seen_side_effect
+    )
+    notes = [f"service_script: {note}" for note in service_notes] + [
+        f"components_script: {note}" for note in component_notes
+    ]
+    return sanitized_service, sanitized_components, notes
+
+
+def detect_duplicate_component_registrations(runtime_text: str) -> List[str]:
+    """Return pfusch component names registered more than once."""
+    names = _PFUSCH_REGISTRATION_RE.findall(runtime_text or "")
+    counts: Dict[str, int] = {}
+    for name in names:
+        counts[name] = counts.get(name, 0) + 1
+    return sorted(name for name, count in counts.items() if count > 1)
+
+
+def enforce_runtime_script_integrity(
+    payload: Dict[str, Any],
+) -> Tuple[List[str], List[str]]:
+    """Auto-fix duplicate imports in *payload* (mutates) and report
+    unfixable integrity issues.
+
+    Returns ``(fix_notes, errors)`` — non-empty ``errors`` means the payload
+    must be rejected (e.g. a component is registered twice)."""
+    service = payload.get("service_script")
+    components = payload.get("components_script")
+    service_text = service if isinstance(service, str) else ""
+    components_text = components if isinstance(components, str) else ""
+
+    sanitized_service, sanitized_components, notes = sanitize_runtime_imports(
+        service_text, components_text
+    )
+    if isinstance(service, str) and sanitized_service != service:
+        payload["service_script"] = sanitized_service
+    if isinstance(components, str) and sanitized_components != components:
+        payload["components_script"] = sanitized_components
+
+    duplicates = detect_duplicate_component_registrations(
+        f"{sanitized_service}\n{sanitized_components}"
+    )
+    errors = [
+        (
+            f"component '{name}' is registered more than once via pfusch(...); "
+            "modify the existing component with a 'replace' operation instead of "
+            "adding another copy"
+        )
+        for name in duplicates
+    ]
+    return notes, errors

--- a/app/app_facade/patch_ops.py
+++ b/app/app_facade/patch_ops.py
@@ -190,7 +190,16 @@ def apply_patch_operations(
                     "current file content."
                 )
                 continue
-            if op_raw.get("replace_all"):
+            replace_all = bool(op_raw.get("replace_all"))
+            if occurrences > 1 and not replace_all:
+                errors.append(
+                    f"op[{index}]: ambiguous search text matches {occurrences} "
+                    f"times in '{target}': '{_preview(search)}'. Include more "
+                    "surrounding context to make it match only once, or set "
+                    "replace_all=true if every occurrence should change."
+                )
+                continue
+            if replace_all:
                 updated = current.replace(search, content)
             else:
                 updated = current.replace(search, content, 1)
@@ -211,104 +220,212 @@ def apply_patch_operations(
 # ---------------------------------------------------------------------------
 
 _IMPORT_LINE_RE = re.compile(r"^[ \t]*import\b")
-_NAMED_IMPORTS_RE = re.compile(r"\{([^}]*)\}")
-_DEFAULT_IMPORT_RE = re.compile(r"^\s*import\s+([A-Za-z_$][\w$]*)\s*(?:,|\s+from\b)")
-_NAMESPACE_IMPORT_RE = re.compile(r"\*\s*as\s+([A-Za-z_$][\w$]*)")
+# Captures the binding clause between `import` and `from '<source>'` so the
+# module specifier is available for source-aware dedup (see
+# ``sanitize_runtime_imports`` docstring for why the specifier matters).
+_IMPORT_CLAUSE_RE = re.compile(
+    r"^(?P<prefix>[ \t]*import\s+)(?P<clause>.+?)\s+from\s+"
+    r"(?P<quote>['\"])(?P<source>[^'\"]+)(?P=quote)(?P<suffix>\s*;?\s*)$"
+)
+_CLAUSE_NAMESPACE_RE = re.compile(r"\*\s*as\s+([A-Za-z_$][\w$]*)")
+_CLAUSE_NAMED_RE = re.compile(r"\{([^}]*)\}")
+_CLAUSE_DEFAULT_RE = re.compile(r"^([A-Za-z_$][\w$]*)")
 _PFUSCH_REGISTRATION_RE = re.compile(r"\bpfusch\(\s*['\"]([A-Za-z][\w-]*)['\"]")
 
 
-def _import_line_identifiers(line: str) -> List[str]:
-    identifiers: List[str] = []
-    default_match = _DEFAULT_IMPORT_RE.match(line)
-    if default_match:
-        identifiers.append(default_match.group(1))
-    namespace_match = _NAMESPACE_IMPORT_RE.search(line)
-    if namespace_match:
-        identifiers.append(namespace_match.group(1))
-    named_match = _NAMED_IMPORTS_RE.search(line)
+def _parse_import_clause(
+    clause: str,
+) -> Tuple[Optional[str], Optional[str], List[Tuple[str, str]]]:
+    """Split an import clause into ``(default_id, namespace_id, named_pairs)``.
+
+    ``named_pairs`` is a list of ``(raw_text, local_name)`` so the original
+    ``orig as alias`` text can be reconstructed verbatim when rebuilding a
+    trimmed clause.
+    """
+    clause = clause.strip()
+    namespace_match = _CLAUSE_NAMESPACE_RE.search(clause)
+    namespace_id = namespace_match.group(1) if namespace_match else None
+
+    named_pairs: List[Tuple[str, str]] = []
+    named_match = _CLAUSE_NAMED_RE.search(clause)
     if named_match:
         for part in named_match.group(1).split(","):
             part = part.strip()
             if not part:
                 continue
-            # `orig as alias` binds the alias
-            alias = part.split(" as ")[-1].strip()
-            if alias:
-                identifiers.append(alias)
-    return identifiers
+            local = part.split(" as ")[-1].strip()
+            if local:
+                named_pairs.append((part, local))
+
+    default_id: Optional[str] = None
+    if not clause.startswith("{") and not clause.startswith("*"):
+        default_match = _CLAUSE_DEFAULT_RE.match(clause)
+        if default_match:
+            default_id = default_match.group(1)
+
+    return default_id, namespace_id, named_pairs
+
+
+def _rebuild_import_clause(
+    default_id: Optional[str],
+    namespace_id: Optional[str],
+    named_pairs: List[Tuple[str, str]],
+) -> str:
+    parts: List[str] = []
+    if default_id:
+        parts.append(default_id)
+    if namespace_id:
+        parts.append(f"* as {namespace_id}")
+    if named_pairs:
+        parts.append("{ " + ", ".join(raw for raw, _local in named_pairs) + " }")
+    return ", ".join(parts)
 
 
 def _dedupe_imports_in_text(
-    text: str, declared: Set[str], seen_side_effect_imports: Set[str]
+    text: str,
+    declared: Dict[str, str],
+    seen_exact_lines: Set[str],
+    conflicts: List[str],
 ) -> Tuple[str, List[str]]:
-    """Remove/trim import lines whose identifiers were already declared."""
+    """Remove import bindings that exactly duplicate an already-declared
+    ``(identifier, source module)`` pair; leave genuine cross-module naming
+    conflicts untouched but recorded in *conflicts* (see
+    ``sanitize_runtime_imports``)."""
     notes: List[str] = []
     out_lines: List[str] = []
     for line in text.split("\n"):
-        if not _IMPORT_LINE_RE.match(line) or " from " not in f" {line} ":
-            side_effect = _IMPORT_LINE_RE.match(line) and re.search(
-                r"import\s+['\"]", line
-            )
-            if side_effect:
-                normalized = line.strip()
-                if normalized in seen_side_effect_imports:
-                    notes.append(f"dropped duplicate side-effect import: {normalized}")
-                    continue
-                seen_side_effect_imports.add(normalized)
+        if not _IMPORT_LINE_RE.match(line):
             out_lines.append(line)
             continue
 
-        identifiers = _import_line_identifiers(line)
-        if not identifiers:
+        clause_match = _IMPORT_CLAUSE_RE.match(line)
+        if not clause_match:
+            # Side-effect import (`import 'x';`) or a shape this sanitizer
+            # doesn't parse (e.g. multi-line braces) — only dedupe on exact
+            # text match, never guess at identifiers without a known source.
+            normalized = line.strip()
+            if normalized.startswith("import"):
+                if normalized in seen_exact_lines:
+                    notes.append(f"dropped duplicate import line: {normalized}")
+                    continue
+                seen_exact_lines.add(normalized)
             out_lines.append(line)
             continue
-        duplicated = [name for name in identifiers if name in declared]
-        fresh = [name for name in identifiers if name not in declared]
-        declared.update(fresh)
-        if not duplicated:
+
+        source = clause_match.group("source")
+        default_id, namespace_id, named_pairs = _parse_import_clause(
+            clause_match.group("clause")
+        )
+        bindings: List[Tuple[str, str]] = []  # (kind, name)
+        if default_id:
+            bindings.append(("default", default_id))
+        if namespace_id:
+            bindings.append(("namespace", namespace_id))
+        bindings.extend(("named", local) for _raw, local in named_pairs)
+        if not bindings:
             out_lines.append(line)
             continue
-        if not fresh:
+
+        # A genuine conflict is the SAME identifier bound to a DIFFERENT
+        # source module. Silently keeping either side would change which
+        # module a reference resolves to, so leave the line untouched and
+        # surface it as an unfixable error instead of guessing.
+        line_has_conflict = False
+        for _kind, name in bindings:
+            prior_source = declared.get(name)
+            if prior_source is not None and prior_source != source:
+                conflicts.append(
+                    f"identifier '{name}' imported from both '{prior_source}' "
+                    f"and '{source}'"
+                )
+                line_has_conflict = True
+        if line_has_conflict:
+            for _kind, name in bindings:
+                declared.setdefault(name, source)
+            out_lines.append(line)
+            continue
+
+        # No conflict on this line — safe to drop any binding that exactly
+        # repeats an already-declared (identifier, source) pair, regardless
+        # of whether it's the default, namespace, or a named binding.
+        dropped: List[str] = []
+        kept_default: Optional[str] = None
+        kept_namespace: Optional[str] = None
+        kept_named: List[Tuple[str, str]] = []
+        if default_id is not None:
+            if default_id in declared:
+                dropped.append(default_id)
+            else:
+                declared[default_id] = source
+                kept_default = default_id
+        if namespace_id is not None:
+            if namespace_id in declared:
+                dropped.append(namespace_id)
+            else:
+                declared[namespace_id] = source
+                kept_namespace = namespace_id
+        for raw, local in named_pairs:
+            if local in declared:
+                dropped.append(local)
+            else:
+                declared[local] = source
+                kept_named.append((raw, local))
+
+        if not dropped:
+            out_lines.append(line)
+            continue
+
+        if not kept_default and not kept_namespace and not kept_named:
             notes.append(
-                f"dropped duplicate import of {{{', '.join(duplicated)}}}"
+                f"dropped duplicate import of {{{', '.join(dropped)}}} from "
+                f"'{source}'"
             )
             continue
-        named_match = _NAMED_IMPORTS_RE.search(line)
-        if named_match:
-            rewritten = (
-                line[: named_match.start()]
-                + "{ "
-                + ", ".join(fresh)
-                + " }"
-                + line[named_match.end() :]
-            )
-            notes.append(
-                f"removed already-imported {{{', '.join(duplicated)}}} from import"
-            )
-            out_lines.append(rewritten)
-        else:
-            # Cannot safely trim non-named imports; keep the line untouched.
-            out_lines.append(line)
+
+        new_clause = _rebuild_import_clause(kept_default, kept_namespace, kept_named)
+        rebuilt = (
+            f"{clause_match.group('prefix')}{new_clause} from "
+            f"{clause_match.group('quote')}{source}{clause_match.group('quote')}"
+            f"{clause_match.group('suffix')}"
+        )
+        notes.append(
+            f"removed already-imported {{{', '.join(dropped)}}} from '{source}' import"
+        )
+        out_lines.append(rebuilt)
     return "\n".join(out_lines), notes
 
 
 def sanitize_runtime_imports(
     service_script: str, components_script: str
-) -> Tuple[str, str, List[str]]:
+) -> Tuple[str, str, List[str], List[str]]:
     """Drop duplicate import declarations across the concatenated runtime
-    scripts (service first, then components — the bundling order)."""
-    declared: Set[str] = set()
-    seen_side_effect: Set[str] = set()
+    scripts (service first, then components — the bundling order).
+
+    Only an import that repeats an IDENTICAL ``(identifier, source module)``
+    pair is treated as a safe, redundant duplicate and removed. When the
+    same local identifier is imported from two *different* source modules
+    (e.g. ``{ format }`` from both ``./dates.js`` and ``./numbers.js``),
+    that's a genuine naming conflict, not a redundant duplicate — silently
+    dropping either side would silently change which module later references
+    resolve to. Conflicts are left untouched in the returned scripts and
+    reported in ``conflicts`` instead, so the caller can reject the payload
+    and ask the model to alias one of the imports.
+
+    Returns ``(sanitized_service, sanitized_components, notes, conflicts)``.
+    """
+    declared: Dict[str, str] = {}
+    seen_exact_lines: Set[str] = set()
+    conflicts: List[str] = []
     sanitized_service, service_notes = _dedupe_imports_in_text(
-        service_script or "", declared, seen_side_effect
+        service_script or "", declared, seen_exact_lines, conflicts
     )
     sanitized_components, component_notes = _dedupe_imports_in_text(
-        components_script or "", declared, seen_side_effect
+        components_script or "", declared, seen_exact_lines, conflicts
     )
     notes = [f"service_script: {note}" for note in service_notes] + [
         f"components_script: {note}" for note in component_notes
     ]
-    return sanitized_service, sanitized_components, notes
+    return sanitized_service, sanitized_components, notes, conflicts
 
 
 def detect_duplicate_component_registrations(runtime_text: str) -> List[str]:
@@ -333,8 +450,8 @@ def enforce_runtime_script_integrity(
     service_text = service if isinstance(service, str) else ""
     components_text = components if isinstance(components, str) else ""
 
-    sanitized_service, sanitized_components, notes = sanitize_runtime_imports(
-        service_text, components_text
+    sanitized_service, sanitized_components, notes, conflicts = (
+        sanitize_runtime_imports(service_text, components_text)
     )
     if isinstance(service, str) and sanitized_service != service:
         payload["service_script"] = sanitized_service
@@ -352,4 +469,9 @@ def enforce_runtime_script_integrity(
         )
         for name in duplicates
     ]
+    errors.extend(
+        f"import conflict: {conflict}; alias one of the imports to a distinct "
+        "local name so both modules can be referenced"
+        for conflict in conflicts
+    )
     return notes, errors

--- a/app/app_facade/sse.py
+++ b/app/app_facade/sse.py
@@ -1,0 +1,22 @@
+"""Shared Server-Sent-Events formatting helpers for the app_facade module."""
+
+import json
+from typing import Any, Dict
+
+
+def sse_event(event: str, payload: Dict[str, Any]) -> bytes:
+    return (
+        f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode(
+            "utf-8"
+        )
+    )
+
+
+def assistant_status_event(status: str) -> bytes:
+    return sse_event(
+        "assistant",
+        {
+            "delta": status,
+            "is_status": True,
+        },
+    )

--- a/app/app_facade/test_fix_tools.py
+++ b/app/app_facade/test_fix_tools.py
@@ -21,6 +21,10 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from app.app_facade.env_utils import positive_int_env
 from app.app_facade.generated_output_factory import MCP_SERVICE_TEST_HELPER_SCRIPT
+from app.app_facade.patch_ops import (
+    detect_duplicate_component_registrations,
+    sanitize_runtime_imports,
+)
 from app.vars import GENERATED_UI_READ_ONLY_STREAK_LIMIT, LLM_MAX_PAYLOAD_BYTES
 from app.tgi.models import (
     ChatCompletionRequest,
@@ -41,6 +45,7 @@ _SCRIPT_TYPE_TO_FILENAME = {
     "dummy-data": "dummy_data.js",
     "domstubs": "domstubs.js",
     "pfusch": "pfusch.js",
+    "app": "app.js (combined)",
 }
 
 TOOL_DESCRIPTIONS = {
@@ -572,37 +577,77 @@ class IterativeTestFixer:
             script = str(script)
         return len(script.split("\n"))
 
+    @staticmethod
+    def _normalize_pfusch_imports(source: Optional[str]) -> str:
+        text = source or ""
+        return (
+            text.replace(
+                "https://matthiaskainer.github.io/pfusch/pfusch.min.js",
+                "./pfusch.js",
+            )
+            .replace(
+                "https://matthiaskainer.github.io/pfusch/pfusch.js",
+                "./pfusch.js",
+            )
+            .replace(
+                "https://matthiaskainer.github.io/pfusch/pfusch.min.mjs",
+                "./pfusch.js",
+            )
+        )
+
+    def _combined_app_script(self) -> str:
+        """The combined runtime module exactly as run_tests writes app.js.
+
+        Test stack traces reference line numbers in THIS file, not in the
+        individual service/components scripts."""
+        return (
+            f"{MCP_SERVICE_TEST_HELPER_SCRIPT}\n\n"
+            + self._normalize_pfusch_imports(self.current_service_script)
+            + "\n\n"
+            + self._normalize_pfusch_imports(self.current_components_script)
+        )
+
+    def _runtime_integrity_warning(self) -> Optional[str]:
+        """Warn about duplicate imports / component registrations across the
+        concatenated service+components module right after a mutation, so the
+        model sees the problem immediately instead of via a load-time
+        SyntaxError on the next test run."""
+        problems: List[str] = []
+        _service, _components, import_notes = sanitize_runtime_imports(
+            self.current_service_script or "",
+            self.current_components_script or "",
+        )
+        if import_notes:
+            problems.append(
+                "duplicate import declarations across service+components "
+                f"(bundled into one module): {'; '.join(import_notes)}"
+            )
+        duplicates = detect_duplicate_component_registrations(
+            f"{self.current_service_script or ''}\n{self.current_components_script or ''}"
+        )
+        if duplicates:
+            problems.append(
+                "components registered more than once via pfusch(...): "
+                + ", ".join(duplicates)
+            )
+        if not problems:
+            return None
+        return (
+            "WARNING - runtime integrity: "
+            + " | ".join(problems)
+            + ". Remove the duplicates before running tests; service and "
+            "components scripts are concatenated into a single ES module."
+        )
+
     def _write_current_files(self) -> None:
         """Write current scripts to temporary directory."""
         if not self.tmpdir:
             raise RuntimeError("Test environment not set up")
 
-        def _normalize_pfusch_imports(source: Optional[str]) -> str:
-            text = source or ""
-            return (
-                text.replace(
-                    "https://matthiaskainer.github.io/pfusch/pfusch.min.js",
-                    "./pfusch.js",
-                )
-                .replace(
-                    "https://matthiaskainer.github.io/pfusch/pfusch.js",
-                    "./pfusch.js",
-                )
-                .replace(
-                    "https://matthiaskainer.github.io/pfusch/pfusch.min.mjs",
-                    "./pfusch.js",
-                )
-            )
+        _normalize_pfusch_imports = self._normalize_pfusch_imports
 
         # Write combined service + components script to mirror production bundling.
-        mocked_service = _normalize_pfusch_imports(self.current_service_script)
-        mocked_components = _normalize_pfusch_imports(self.current_components_script)
-        combined_script = (
-            f"{MCP_SERVICE_TEST_HELPER_SCRIPT}\n\n"
-            + mocked_service
-            + "\n\n"
-            + mocked_components
-        )
+        combined_script = self._combined_app_script()
         with open(os.path.join(self.tmpdir, "app.js"), "w", encoding="utf-8") as f:
             f.write(combined_script)
         with open(
@@ -923,6 +968,14 @@ class IterativeTestFixer:
                 success=False,
                 content=f"{script_type} is read-only and cannot be patched.",
             )
+        if script_type == "app":
+            return ToolResult(
+                success=False,
+                content=(
+                    "'app' is the read-only combined view; patch 'service' or "
+                    "'components' instead."
+                ),
+            )
 
         script_map: Dict[str, Optional[str]] = {
             "test": self.current_test_script,
@@ -977,11 +1030,15 @@ class IterativeTestFixer:
         elif script_type == "dummy_data":
             self.current_dummy_data = updated
 
+        content = f"Patched {script_type} successfully. Replacements applied: {count}."
+        if script_type in {"service", "components"}:
+            warning = self._runtime_integrity_warning()
+            if warning:
+                content = f"{content}\n{warning}"
+
         return ToolResult(
             success=True,
-            content=(
-                f"Patched {script_type} successfully. Replacements applied: {count}."
-            ),
+            content=content,
             metadata={"replacements": count, "script_type": script_type},
         )
 
@@ -1017,9 +1074,13 @@ class IterativeTestFixer:
         """
         try:
             self.current_service_script = new_script
+            content = "Service script updated successfully."
+            warning = self._runtime_integrity_warning()
+            if warning:
+                content = f"{content}\n{warning}"
             return ToolResult(
                 success=True,
-                content="Service script updated successfully.",
+                content=content,
                 metadata={"length": len(new_script)},
             )
         except Exception as e:
@@ -1039,9 +1100,13 @@ class IterativeTestFixer:
         """
         try:
             self.current_components_script = new_script
+            content = "Components script updated successfully."
+            warning = self._runtime_integrity_warning()
+            if warning:
+                content = f"{content}\n{warning}"
             return ToolResult(
                 success=True,
-                content="Components script updated successfully.",
+                content=content,
                 metadata={"length": len(new_script)},
             )
         except Exception as e:
@@ -1083,6 +1148,7 @@ class IterativeTestFixer:
                 "dummy_data": self.current_dummy_data,
                 "domstubs": self._get_helper_content("domstubs.js"),
                 "pfusch": self._get_helper_content("pfusch.js"),
+                "app": self._combined_app_script(),
             }
 
             script = script_map.get(script_type)
@@ -1129,6 +1195,7 @@ class IterativeTestFixer:
                 "dummy_data": "dummy_data.js",
                 "domstubs": os.path.join(self.helpers_dir, "domstubs.js"),
                 "pfusch": os.path.join(self.helpers_dir, "pfusch.js"),
+                "app": "app.js",
             }
             filename = filename_map.get(script_type, f"{script_type}.js")
 
@@ -1400,7 +1467,9 @@ class IterativeTestFixer:
                     "description": (
                         "Read specific lines from a script file for inspection. "
                         "Useful for examining code before making changes. "
-                        "Can also read read-only helper scripts 'domstubs' and 'pfusch'. "
+                        "Can also read read-only helper scripts 'domstubs' and 'pfusch', "
+                        "and 'app' — the combined helper+service+components module that "
+                        "test stack-trace line numbers (app.js:NNN) refer to. "
                         "If line numbers are omitted, returns the entire file."
                     ),
                     "parameters": {
@@ -1416,8 +1485,13 @@ class IterativeTestFixer:
                                     "dummy-data",
                                     "domstubs",
                                     "pfusch",
+                                    "app",
                                 ],
-                                "description": "Which script to read from",
+                                "description": (
+                                    "Which script to read from. Use 'app' to resolve "
+                                    "app.js:NNN stack-trace locations; edit via "
+                                    "'service'/'components'."
+                                ),
                             },
                             "start_line": {
                                 "type": "integer",
@@ -1458,8 +1532,13 @@ class IterativeTestFixer:
                                     "dummy-data",
                                     "domstubs",
                                     "pfusch",
+                                    "app",
                                 ],
-                                "description": "Optional. Specific script to search. If omitted, searches all.",
+                                "description": (
+                                    "Optional. Specific script to search. If omitted, "
+                                    "searches all. 'app' is the combined module that "
+                                    "stack traces reference."
+                                ),
                             },
                         },
                         "required": ["regex"],
@@ -1590,11 +1669,16 @@ class IterativeTestFixer:
                 "dummy_data": self.current_dummy_data,
                 "domstubs": self._get_helper_content("domstubs.js"),
                 "pfusch": self._get_helper_content("pfusch.js"),
+                "app": self._combined_app_script(),
             }
 
             results = []
+            # 'app' duplicates service+components content; only search it
+            # when explicitly requested.
             files_to_search = (
-                [script_type] if script_type in script_map else script_map.keys()
+                [script_type]
+                if script_type in script_map
+                else [name for name in script_map.keys() if name != "app"]
             )
 
             for name in files_to_search:

--- a/app/app_facade/test_fix_tools.py
+++ b/app/app_facade/test_fix_tools.py
@@ -613,14 +613,22 @@ class IterativeTestFixer:
         model sees the problem immediately instead of via a load-time
         SyntaxError on the next test run."""
         problems: List[str] = []
-        _service, _components, import_notes = sanitize_runtime_imports(
-            self.current_service_script or "",
-            self.current_components_script or "",
+        _service, _components, import_notes, import_conflicts = (
+            sanitize_runtime_imports(
+                self.current_service_script or "",
+                self.current_components_script or "",
+            )
         )
         if import_notes:
             problems.append(
                 "duplicate import declarations across service+components "
                 f"(bundled into one module): {'; '.join(import_notes)}"
+            )
+        if import_conflicts:
+            problems.append(
+                "conflicting imports across service+components — same identifier "
+                "bound to two different source modules, alias one of them: "
+                + "; ".join(import_conflicts)
             )
         duplicates = detect_duplicate_component_registrations(
             f"{self.current_service_script or ''}\n{self.current_components_script or ''}"

--- a/app/app_facade/test_generation_pipeline_retry.py
+++ b/app/app_facade/test_generation_pipeline_retry.py
@@ -1,0 +1,241 @@
+"""Direct tests for the shared retry/persist core in generation_pipeline.py.
+
+``_stream_generate_and_persist`` is exercised end-to-end elsewhere via a fake
+LLM stream (test_generated_service.py), but that only covers the
+happy-path/persist-failure cases on the first attempt. These tests target
+the behavioral surface that changed with the create/update merge: retry-
+feedback injection across attempts, immediate abort on a fatal LLM error,
+and the create-vs-update instruction/merge branch — by faking
+``_phase_1_attempt``/``_phase_2_attempt`` directly so each scenario is
+deterministic and fast.
+"""
+
+import os
+
+import pytest
+
+from app.app_facade.generated_service import GeneratedUIService, GeneratedUIStorage
+from app.app_facade.generated_types import Actor, Scope
+from app.app_facade.generation_pipeline import GenerationPipeline
+from app.tgi.models import MessageRole
+
+
+class DummyTGIService:
+    def __init__(self):
+        self.llm_client = None
+        self.prompt_service = None
+        self.tool_service = None
+
+
+class PS:
+    async def find_prompt_by_name_or_role(self, session, prompt_name=None):
+        return None
+
+
+class NoTools:
+    async def get_all_mcp_tools(self, session, include_output_schema=True):
+        return []
+
+
+def _make_service(tmp_path, monkeypatch):
+    storage = GeneratedUIStorage(str(tmp_path))
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+    monkeypatch.setattr(
+        "app.app_facade.generated_service._load_pfusch_prompt",
+        lambda: "PROMPT {{DESIGN_SYSTEM_PROMPT}}",
+    )
+    service.tgi_service.prompt_service = PS()
+    service.tgi_service.tool_service = NoTools()
+    return service
+
+
+def _phase2_payload():
+    return {
+        "type": "result",
+        "success": True,
+        "payload": {
+            "template_parts": {
+                "title": "t",
+                "styles": "",
+                "html": "<app-root></app-root>",
+                "script": "",
+            },
+            "metadata": {},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_carries_prior_failure_reason_into_next_attempt(
+    tmp_path, monkeypatch
+):
+    service = _make_service(tmp_path, monkeypatch)
+    captured_messages_by_attempt = {}
+
+    async def fake_phase_1_attempt(
+        self, *, attempt, max_attempts, messages, allowed_tools, dummy_data, access_token
+    ):
+        captured_messages_by_attempt[attempt] = list(messages)
+        if attempt == 1:
+            yield {
+                "type": "result",
+                "success": False,
+                "reason": "boom on first try",
+                "messages": messages,
+            }
+            return
+        yield {
+            "type": "result",
+            "success": True,
+            "payload": {
+                "components_script": "export const s = 1;",
+                "test_script": "test('x', () => {});",
+            },
+            "messages": messages,
+        }
+
+    async def fake_phase_2_attempt(self, **_kwargs):
+        yield _phase2_payload()
+
+    monkeypatch.setattr(GenerationPipeline, "_phase_1_attempt", fake_phase_1_attempt)
+    monkeypatch.setattr(GenerationPipeline, "_phase_2_attempt", fake_phase_2_attempt)
+
+    gen = service.generation_pipeline.stream_generate_ui(
+        session=None,
+        scope=Scope(kind="user", identifier="u1"),
+        actor=Actor(user_id="u1", groups=[]),
+        ui_id="retry1",
+        name="n",
+        prompt="build a thing",
+        tools=None,
+        access_token=None,
+    )
+    async for _ in gen:
+        pass
+
+    assert set(captured_messages_by_attempt.keys()) == {1, 2}
+    second_attempt_contents = [
+        m.content for m in captured_messages_by_attempt[2] if m.role == MessageRole.USER
+    ]
+    assert any(
+        "Previous generation attempt(s) failed" in c and "boom on first try" in c
+        for c in second_attempt_contents
+    )
+    # the failed first attempt's own messages must not leak into attempt 2
+    # beyond the compact summary — i.e. attempt 2 starts from the pristine
+    # base messages plus exactly one extra feedback message.
+    assert len(captured_messages_by_attempt[2]) == len(
+        captured_messages_by_attempt[1]
+    ) + 1
+
+
+@pytest.mark.asyncio
+async def test_fatal_llm_error_aborts_without_further_retries(tmp_path, monkeypatch):
+    service = _make_service(tmp_path, monkeypatch)
+    call_count = {"n": 0}
+
+    async def fake_phase_1_attempt_fatal(
+        self, *, attempt, max_attempts, messages, allowed_tools, dummy_data, access_token
+    ):
+        call_count["n"] += 1
+        yield {
+            "type": "result",
+            "success": False,
+            "reason": "insufficient_quota: no budget left",
+            "messages": messages,
+        }
+
+    monkeypatch.setattr(
+        GenerationPipeline, "_phase_1_attempt", fake_phase_1_attempt_fatal
+    )
+
+    gen = service.generation_pipeline.stream_generate_ui(
+        session=None,
+        scope=Scope(kind="user", identifier="u2"),
+        actor=Actor(user_id="u2", groups=[]),
+        ui_id="fatal1",
+        name="n",
+        prompt="build a thing",
+        tools=None,
+        access_token=None,
+    )
+    events = []
+    async for chunk in gen:
+        events.append(chunk)
+
+    assert call_count["n"] == 1  # no retries after a fatal error
+    assert any(b"error" in e for e in events)
+    assert not service.storage.exists(Scope(kind="user", identifier="u2"), "fatal1", "n")
+
+
+@pytest.mark.asyncio
+async def test_create_and_update_use_distinct_phase2_instructions_and_merge_correctly(
+    tmp_path, monkeypatch
+):
+    service = _make_service(tmp_path, monkeypatch)
+    instructions = []
+
+    async def fake_phase_1_attempt(
+        self, *, attempt, max_attempts, messages, allowed_tools, dummy_data, access_token
+    ):
+        yield {
+            "type": "result",
+            "success": True,
+            "payload": {
+                "components_script": "export const s = 1;",
+                "test_script": "test('x', () => {});",
+            },
+            "messages": messages,
+        }
+
+    async def fake_phase_2_attempt(self, *, instruction, **_kwargs):
+        instructions.append(instruction)
+        yield _phase2_payload()
+
+    monkeypatch.setattr(GenerationPipeline, "_phase_1_attempt", fake_phase_1_attempt)
+    monkeypatch.setattr(GenerationPipeline, "_phase_2_attempt", fake_phase_2_attempt)
+
+    scope = Scope(kind="user", identifier="u3")
+    actor = Actor(user_id="u3", groups=[])
+
+    create_gen = service.generation_pipeline.stream_generate_ui(
+        session=None,
+        scope=scope,
+        actor=actor,
+        ui_id="merge1",
+        name="n",
+        prompt="build a thing",
+        tools=None,
+        access_token=None,
+    )
+    async for _ in create_gen:
+        pass
+
+    created = service.storage.read(scope, "merge1", "n")
+    assert created["metadata"]["version"] == 1
+    assert len(created["metadata"]["history"]) == 1
+    assert created["metadata"]["history"][0]["action"] == "create"
+    assert "generate" in instructions[0]
+    assert "update" not in instructions[0]
+
+    update_gen = service.generation_pipeline.stream_update_ui(
+        session=None,
+        scope=scope,
+        actor=actor,
+        ui_id="merge1",
+        name="n",
+        prompt="change a thing",
+        tools=None,
+        access_token=None,
+    )
+    async for _ in update_gen:
+        pass
+
+    updated = service.storage.read(scope, "merge1", "n")
+    assert updated["metadata"]["version"] == 2
+    assert len(updated["metadata"]["history"]) == 2
+    assert updated["metadata"]["history"][1]["action"] == "update"
+    assert "update" in instructions[1]
+    # the previously-created record was merged into (not replaced wholesale)
+    assert updated["metadata"]["created_by"] == created["metadata"]["created_by"]
+    assert updated["current"]["components_script"] == "export const s = 1;"

--- a/app/app_facade/test_patch_ops.py
+++ b/app/app_facade/test_patch_ops.py
@@ -1,0 +1,437 @@
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from app.app_facade.generated_service import GeneratedUIService, GeneratedUIStorage
+from app.app_facade.generated_types import Scope
+from app.app_facade.patch_ops import (
+    PATCH_UPDATE_SCHEMA,
+    apply_patch_operations,
+    detect_duplicate_component_registrations,
+    enforce_runtime_script_integrity,
+    legacy_patch_to_operations,
+    sanitize_runtime_imports,
+)
+
+
+class DummyTGIService:
+    def __init__(self):
+        self.llm_client = None
+        self.prompt_service = None
+        self.tool_service = None
+
+
+DRAFT = {
+    "html": {"page": "<html><body><div>old</div></body></html>", "snippet": "<div>old</div>"},
+    "service_script": "export function getItems() { return svc.call('list_items'); }",
+    "components_script": "pfusch('app-root', {}, (state) => [html.div('hello')]);",
+    "test_script": "test('renders', () => {});",
+    "dummy_data": "export const dummyData = {};",
+    "metadata": {},
+}
+
+
+def test_apply_patch_operations_replace_and_append():
+    candidate, errors = apply_patch_operations(
+        DRAFT,
+        [
+            {
+                "target": "components_script",
+                "op": "replace",
+                "search": "html.div('hello')",
+                "content": "html.div('world')",
+            },
+            {
+                "target": "test_script",
+                "op": "append",
+                "content": "test('new case', () => {});",
+            },
+        ],
+    )
+    assert errors == []
+    assert "html.div('world')" in candidate["components_script"]
+    assert "html.div('hello')" not in candidate["components_script"]
+    assert candidate["test_script"].endswith("test('new case', () => {});")
+    # original untouched
+    assert "html.div('hello')" in DRAFT["components_script"]
+
+
+def test_apply_patch_operations_replace_all_and_html_targets():
+    candidate, errors = apply_patch_operations(
+        {"html": {"page": "a b a", "snippet": "x"}},
+        [
+            {"target": "html_page", "op": "replace", "search": "a", "content": "c", "replace_all": True},
+            {"target": "html_snippet", "op": "set", "content": "<div>new</div>"},
+        ],
+    )
+    assert errors == []
+    assert candidate["html"]["page"] == "c b c"
+    assert candidate["html"]["snippet"] == "<div>new</div>"
+
+
+def test_apply_patch_operations_set_creates_missing_target():
+    candidate, errors = apply_patch_operations(
+        {"html": {}},
+        [{"target": "test_script", "op": "set", "content": "test('x', () => {});"}],
+    )
+    assert errors == []
+    assert candidate["test_script"] == "test('x', () => {});"
+
+
+def test_apply_patch_operations_is_all_or_nothing():
+    candidate, errors = apply_patch_operations(
+        DRAFT,
+        [
+            {
+                "target": "components_script",
+                "op": "replace",
+                "search": "html.div('hello')",
+                "content": "html.div('world')",
+            },
+            {
+                "target": "service_script",
+                "op": "replace",
+                "search": "does-not-exist-anywhere",
+                "content": "whatever",
+            },
+        ],
+    )
+    assert candidate is None
+    assert len(errors) == 1
+    assert "search text not found" in errors[0]
+    assert "service_script" in errors[0]
+
+
+def test_apply_patch_operations_rejects_empty_and_invalid():
+    candidate, errors = apply_patch_operations(DRAFT, [])
+    assert candidate is None
+    assert errors == ["no_operations_provided"]
+
+    candidate, errors = apply_patch_operations(
+        DRAFT,
+        [
+            {"target": "nope", "op": "set", "content": "x"},
+            {"target": "test_script", "op": "replace", "content": "x"},
+        ],
+    )
+    assert candidate is None
+    assert any("unknown_target" in e for e in errors)
+    assert any("non-empty 'search'" in e for e in errors)
+
+
+def test_legacy_patch_to_operations_converts_whole_file_keys():
+    ops = legacy_patch_to_operations(
+        {
+            "html": {"page": "<html>new</html>", "snippet": ""},
+            "components_script": "new comp",
+            "metadata": {"x": 1},
+        }
+    )
+    assert {"target": "html_page", "op": "set", "content": "<html>new</html>"} in ops
+    assert {"target": "components_script", "op": "set", "content": "new comp"} in ops
+    # empty snippet and metadata are not converted into operations
+    assert all(op["target"] != "html_snippet" for op in ops)
+
+
+def test_patch_update_schema_shape():
+    patch_props = PATCH_UPDATE_SCHEMA["properties"]["patch"]
+    assert "operations" in patch_props["properties"]
+    assert patch_props["required"] == ["operations"]
+
+
+@pytest.mark.asyncio
+async def test_attempt_patch_update_applies_operations_and_passes_feedback():
+    storage = GeneratedUIStorage(os.getcwd())
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+
+    captured = {}
+
+    async def fake_non_stream_completion(request, _token, _span):
+        captured["request"] = request
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "patch": {
+                                    "operations": [
+                                        {
+                                            "target": "components_script",
+                                            "op": "replace",
+                                            "search": "html.div('hello')",
+                                            "content": "html.div('patched')",
+                                        }
+                                    ]
+                                }
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+
+    service.tgi_service.llm_client = SimpleNamespace(
+        non_stream_completion=fake_non_stream_completion
+    )
+    # no test_script execution path needed
+    service._run_tests = lambda *_a, **_k: (True, "ok")
+
+    result = await service.conversational_service._attempt_patch_update(
+        scope=Scope(kind="user", identifier="u1"),
+        ui_id="ui1",
+        name="dash",
+        draft_payload=dict(DRAFT),
+        user_message="change greeting",
+        assistant_message="I will change it",
+        access_token=None,
+        previous_metadata={},
+        failure_feedback="op[0]: search text not found in 'components_script'",
+    )
+
+    assert result is not None
+    assert "html.div('patched')" in result["payload"]["components_script"]
+
+    user_payload = json.loads(captured["request"].messages[1].content)
+    assert "previous_attempt_failure" in user_payload
+    assert "search text not found" in user_payload["previous_attempt_failure"]
+    # operations vocabulary must be in the system prompt
+    assert "'replace'" in captured["request"].messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_attempt_patch_update_records_apply_failure_reason():
+    storage = GeneratedUIStorage(os.getcwd())
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+
+    async def fake_non_stream_completion(_request, _token, _span):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "patch": {
+                                    "operations": [
+                                        {
+                                            "target": "components_script",
+                                            "op": "replace",
+                                            "search": "not-in-file",
+                                            "content": "x",
+                                        }
+                                    ]
+                                }
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+
+    service.tgi_service.llm_client = SimpleNamespace(
+        non_stream_completion=fake_non_stream_completion
+    )
+
+    result = await service.conversational_service._attempt_patch_update(
+        scope=Scope(kind="user", identifier="u1"),
+        ui_id="ui1",
+        name="dash",
+        draft_payload=dict(DRAFT),
+        user_message="change greeting",
+        assistant_message="",
+        access_token=None,
+        previous_metadata={},
+    )
+
+    assert result is None
+    assert service._last_patch_failure_reason.startswith("patch_apply_failed")
+    assert "search text not found" in service._last_patch_failure_reason
+
+
+PFUSCH_IMPORT = (
+    "import { pfusch, html, css, script } from "
+    "'https://matthiaskainer.github.io/pfusch/pfusch.min.js';"
+)
+
+
+def test_sanitize_runtime_imports_drops_exact_duplicate():
+    components = f"{PFUSCH_IMPORT}\npfusch('a-b', {{}}, () => []);\n{PFUSCH_IMPORT}\npfusch('c-d', {{}}, () => []);"
+    service, sanitized, notes = sanitize_runtime_imports("", components)
+    assert sanitized.count("import { pfusch") == 1
+    assert "pfusch('a-b'" in sanitized and "pfusch('c-d'" in sanitized
+    assert notes
+
+
+def test_sanitize_runtime_imports_across_service_and_components():
+    service = f"{PFUSCH_IMPORT}\nexport function x() {{}}"
+    components = f"{PFUSCH_IMPORT}\npfusch('a-b', {{}}, () => []);"
+    sanitized_service, sanitized_components, notes = sanitize_runtime_imports(
+        service, components
+    )
+    assert sanitized_service == service
+    assert "import" not in sanitized_components.split("\n")[0]
+    assert "pfusch('a-b'" in sanitized_components
+    assert notes
+
+
+def test_sanitize_runtime_imports_trims_partial_overlap():
+    service = "import { pfusch } from './pfusch.js';"
+    components = "import { pfusch, html } from './pfusch.js';\npfusch('a-b');"
+    _s, sanitized_components, notes = sanitize_runtime_imports(service, components)
+    first_line = sanitized_components.split("\n")[0]
+    assert "html" in first_line and " pfusch," not in first_line
+    assert notes
+
+
+def test_sanitize_runtime_imports_keeps_distinct_imports():
+    service = "import { a } from './x.js';"
+    components = "import { b } from './y.js';\nimport './side.js';"
+    s, c, notes = sanitize_runtime_imports(service, components)
+    assert s == service
+    assert c == components
+    assert notes == []
+
+
+def test_detect_duplicate_component_registrations():
+    text = (
+        "pfusch('issue-list', {}, () => []);\n"
+        "pfusch('pr-list', {}, () => []);\n"
+        "pfusch('issue-list', {}, () => []);"
+    )
+    assert detect_duplicate_component_registrations(text) == ["issue-list"]
+    assert detect_duplicate_component_registrations("pfusch('one', {})") == []
+
+
+def test_enforce_runtime_script_integrity_fixes_imports_and_flags_duplicates():
+    payload = {
+        "service_script": PFUSCH_IMPORT,
+        "components_script": (
+            f"{PFUSCH_IMPORT}\n"
+            "pfusch('issue-list', {}, () => []);\n"
+            "pfusch('issue-list', {}, () => []);"
+        ),
+    }
+    notes, errors = enforce_runtime_script_integrity(payload)
+    assert notes  # duplicate import removed
+    assert "import" not in payload["components_script"].split("\n")[0]
+    assert len(errors) == 1
+    assert "issue-list" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_attempt_patch_update_rejects_duplicate_component_registration():
+    storage = GeneratedUIStorage(os.getcwd())
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+
+    duplicate_component = (
+        "\npfusch('app-root', {}, (state) => [html.div('copy')]);"
+    )
+
+    async def fake_non_stream_completion(_request, _token, _span):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "patch": {
+                                    "operations": [
+                                        {
+                                            "target": "components_script",
+                                            "op": "append",
+                                            "content": duplicate_component,
+                                        }
+                                    ]
+                                }
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+
+    service.tgi_service.llm_client = SimpleNamespace(
+        non_stream_completion=fake_non_stream_completion
+    )
+
+    result = await service.conversational_service._attempt_patch_update(
+        scope=Scope(kind="user", identifier="u1"),
+        ui_id="ui1",
+        name="dash",
+        draft_payload=dict(DRAFT),
+        user_message="add a copy of the root",
+        assistant_message="",
+        access_token=None,
+        previous_metadata={},
+    )
+
+    assert result is None
+    assert service._last_patch_failure_reason.startswith("patch_integrity_failed")
+    assert "app-root" in service._last_patch_failure_reason
+
+
+def test_dummy_data_covers_tools():
+    storage = GeneratedUIStorage(os.getcwd())
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+    module = (
+        "export const dummyData = "
+        + json.dumps({"list_items": [{"id": 1}], "get_weather": {"temperature_c": 20}})
+        + ";\nexport const dummyDataSchemaHints = {};"
+    )
+    tools = [
+        {"function": {"name": "list_items"}},
+        {"function": {"name": "get_weather"}},
+        {"function": {"name": "describe_tool"}},  # excluded from sampling
+    ]
+    assert service.tool_sampler.dummy_data_covers_tools(module, tools) is True
+
+    tools.append({"function": {"name": "delete_item"}})
+    assert service.tool_sampler.dummy_data_covers_tools(module, tools) is False
+    assert service.tool_sampler.dummy_data_covers_tools("", tools) is False
+
+
+def test_pipeline_reuses_dummy_data_only_when_covered():
+    storage = GeneratedUIStorage(os.getcwd())
+    service = GeneratedUIService(storage=storage, tgi_service=DummyTGIService())
+    module = (
+        "export const dummyData = "
+        + json.dumps({"list_items": []})
+        + ";\nexport const dummyDataSchemaHints = {};"
+    )
+    previous = {"current": {"dummy_data": module}}
+    tools = [{"function": {"name": "list_items"}}]
+
+    assert (
+        service.generation_pipeline._reusable_dummy_data(
+            previous=previous, allowed_tools=tools
+        )
+        == module
+    )
+    # uncovered tool -> regenerate
+    assert (
+        service.generation_pipeline._reusable_dummy_data(
+            previous=previous,
+            allowed_tools=tools + [{"function": {"name": "get_weather"}}],
+        )
+        is None
+    )
+    # fresh runtime observations -> regenerate
+    assert (
+        service.generation_pipeline._reusable_dummy_data(
+            previous=previous,
+            allowed_tools=tools,
+            runtime_context={
+                "entries": [{"tool": "list_items", "response_payload": {"a": 1}}]
+            },
+        )
+        is None
+    )
+    # create flow (no previous) -> regenerate
+    assert (
+        service.generation_pipeline._reusable_dummy_data(
+            previous=None, allowed_tools=tools
+        )
+        is None
+    )

--- a/app/app_facade/test_patch_ops.py
+++ b/app/app_facade/test_patch_ops.py
@@ -104,6 +104,45 @@ def test_apply_patch_operations_is_all_or_nothing():
     assert "service_script" in errors[0]
 
 
+def test_apply_patch_operations_rejects_ambiguous_search_without_replace_all():
+    payload = {"components_script": "html.div('x'); html.div('x'); html.div('y');"}
+    candidate, errors = apply_patch_operations(
+        payload,
+        [
+            {
+                "target": "components_script",
+                "op": "replace",
+                "search": "html.div('x');",
+                "content": "html.div('z');",
+            }
+        ],
+    )
+    assert candidate is None
+    assert len(errors) == 1
+    assert "ambiguous search text matches 2 times" in errors[0]
+    assert "components_script" in errors[0]
+    # payload itself must remain untouched — no silent first-match patch
+    assert payload["components_script"] == "html.div('x'); html.div('x'); html.div('y');"
+
+
+def test_apply_patch_operations_ambiguous_search_allowed_with_replace_all():
+    payload = {"components_script": "html.div('x'); html.div('x'); html.div('y');"}
+    candidate, errors = apply_patch_operations(
+        payload,
+        [
+            {
+                "target": "components_script",
+                "op": "replace",
+                "search": "html.div('x');",
+                "content": "html.div('z');",
+                "replace_all": True,
+            }
+        ],
+    )
+    assert errors == []
+    assert candidate["components_script"] == "html.div('z'); html.div('z'); html.div('y');"
+
+
 def test_apply_patch_operations_rejects_empty_and_invalid():
     candidate, errors = apply_patch_operations(DRAFT, [])
     assert candidate is None
@@ -258,40 +297,90 @@ PFUSCH_IMPORT = (
 
 def test_sanitize_runtime_imports_drops_exact_duplicate():
     components = f"{PFUSCH_IMPORT}\npfusch('a-b', {{}}, () => []);\n{PFUSCH_IMPORT}\npfusch('c-d', {{}}, () => []);"
-    service, sanitized, notes = sanitize_runtime_imports("", components)
+    service, sanitized, notes, conflicts = sanitize_runtime_imports("", components)
     assert sanitized.count("import { pfusch") == 1
     assert "pfusch('a-b'" in sanitized and "pfusch('c-d'" in sanitized
     assert notes
+    assert conflicts == []
 
 
 def test_sanitize_runtime_imports_across_service_and_components():
     service = f"{PFUSCH_IMPORT}\nexport function x() {{}}"
     components = f"{PFUSCH_IMPORT}\npfusch('a-b', {{}}, () => []);"
-    sanitized_service, sanitized_components, notes = sanitize_runtime_imports(
+    sanitized_service, sanitized_components, notes, conflicts = sanitize_runtime_imports(
         service, components
     )
     assert sanitized_service == service
     assert "import" not in sanitized_components.split("\n")[0]
     assert "pfusch('a-b'" in sanitized_components
     assert notes
+    assert conflicts == []
 
 
 def test_sanitize_runtime_imports_trims_partial_overlap():
     service = "import { pfusch } from './pfusch.js';"
     components = "import { pfusch, html } from './pfusch.js';\npfusch('a-b');"
-    _s, sanitized_components, notes = sanitize_runtime_imports(service, components)
+    _s, sanitized_components, notes, conflicts = sanitize_runtime_imports(
+        service, components
+    )
     first_line = sanitized_components.split("\n")[0]
     assert "html" in first_line and " pfusch," not in first_line
     assert notes
+    assert conflicts == []
 
 
 def test_sanitize_runtime_imports_keeps_distinct_imports():
     service = "import { a } from './x.js';"
     components = "import { b } from './y.js';\nimport './side.js';"
-    s, c, notes = sanitize_runtime_imports(service, components)
+    s, c, notes, conflicts = sanitize_runtime_imports(service, components)
     assert s == service
     assert c == components
     assert notes == []
+    assert conflicts == []
+
+
+def test_sanitize_runtime_imports_does_not_drop_same_name_different_source():
+    # Regression for a silent-corruption bug: 'format' bound from two
+    # different modules must NOT be treated as a redundant duplicate — the
+    # second import must survive untouched so components' reference to
+    # `format` keeps resolving to its own module.
+    service = "import { format } from './dates.js';"
+    components = "import { format, parse } from './numbers.js';\nparse(format(1));"
+    sanitized_service, sanitized_components, notes, conflicts = sanitize_runtime_imports(
+        service, components
+    )
+    assert sanitized_service == service
+    assert sanitized_components == components  # left completely untouched
+    assert len(conflicts) == 1
+    assert "'format'" in conflicts[0]
+    assert "./dates.js" in conflicts[0] and "./numbers.js" in conflicts[0]
+
+
+def test_sanitize_runtime_imports_drops_duplicate_default_in_mixed_import():
+    # Regression: a duplicated default binding inside a default+named import
+    # must be removed too, not just the named-import portion.
+    service = "import React from 'react';"
+    components = "import React, { useMemo } from 'react';\nuseMemo(() => React.createElement('div'));"
+    sanitized_service, sanitized_components, notes, conflicts = sanitize_runtime_imports(
+        service, components
+    )
+    assert sanitized_service == service
+    first_line = sanitized_components.split("\n")[0]
+    assert first_line == "import { useMemo } from 'react';"
+    assert conflicts == []
+    assert notes
+
+
+def test_sanitize_runtime_imports_drops_exact_duplicate_default_only():
+    service = "import Foo from './foo.js';"
+    components = "import Foo from './foo.js';\nFoo();"
+    sanitized_service, sanitized_components, notes, conflicts = sanitize_runtime_imports(
+        service, components
+    )
+    assert sanitized_service == service
+    assert "import" not in sanitized_components.split("\n")[0]
+    assert conflicts == []
+    assert notes
 
 
 def test_detect_duplicate_component_registrations():
@@ -318,6 +407,20 @@ def test_enforce_runtime_script_integrity_fixes_imports_and_flags_duplicates():
     assert "import" not in payload["components_script"].split("\n")[0]
     assert len(errors) == 1
     assert "issue-list" in errors[0]
+
+
+def test_enforce_runtime_script_integrity_rejects_import_conflict():
+    payload = {
+        "service_script": "import { format } from './dates.js';",
+        "components_script": "import { format } from './numbers.js';\nformat(1);",
+    }
+    original_components = payload["components_script"]
+    notes, errors = enforce_runtime_script_integrity(payload)
+    # left untouched — conflict is reported, not silently resolved either way
+    assert payload["components_script"] == original_components
+    assert len(errors) == 1
+    assert "import conflict" in errors[0]
+    assert "'format'" in errors[0]
 
 
 @pytest.mark.asyncio

--- a/app/app_facade/test_runner_service.py
+++ b/app/app_facade/test_runner_service.py
@@ -32,6 +32,7 @@ from app.app_facade.generated_types import (
     Actor,
     Scope,
 )
+from app.app_facade.sse import assistant_status_event, sse_event
 from app.app_facade.test_fix_tools import _parse_tap_output, run_tool_driven_test_fix
 from app.app_facade.prompt_helpers import (
     parse_json,
@@ -72,22 +73,8 @@ def _generation_response_format(schema=None, name: str = "generated_ui"):
     return generation_response_format(schema=schema, name=name)
 
 
-def _sse_event(event: str, payload: Dict[str, Any]) -> bytes:
-    return (
-        f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode(
-            "utf-8"
-        )
-    )
-
-
-def _assistant_status_event(status: str) -> bytes:
-    return _sse_event(
-        "assistant",
-        {
-            "delta": status,
-            "is_status": True,
-        },
-    )
+_sse_event = sse_event
+_assistant_status_event = assistant_status_event
 
 
 class TestRunnerService:

--- a/app/app_facade/tool_sampling.py
+++ b/app/app_facade/tool_sampling.py
@@ -747,6 +747,35 @@ class ToolSampler:
             analysis_reason=str(analysis.get("reason") or ""),
         )
 
+    @staticmethod
+    def _tool_name_of(tool: Any) -> Optional[str]:
+        if isinstance(tool, dict):
+            function = tool.get("function", {})
+            return function.get("name") or tool.get("name")
+        function = getattr(tool, "function", None)
+        if function is not None and hasattr(function, "name"):
+            return function.name
+        return getattr(tool, "name", None)
+
+    def dummy_data_covers_tools(
+        self,
+        module_source: Optional[str],
+        allowed_tools: Optional[List[Dict[str, Any]]],
+    ) -> bool:
+        """Return True when an existing dummy-data module already has a
+        fixture entry for every selected tool, so the expensive sampling +
+        LLM generation pipeline can be skipped on updates."""
+        payload = self._extract_dummy_data_payload_from_module(module_source)
+        if not payload:
+            return False
+        for tool in allowed_tools or []:
+            tool_name = self._tool_name_of(tool)
+            if not tool_name or tool_name in _DUMMY_DATA_SAMPLING_EXCLUDED_TOOLS:
+                continue
+            if tool_name not in payload:
+                return False
+        return True
+
     def _extract_dummy_data_payload_from_module(
         self, module_source: Optional[str]
     ) -> Dict[str, Any]:
@@ -876,7 +905,7 @@ class ToolSampler:
         if not dummy_payload:
             return tools, 0
 
-        derived_count = 0
+        candidates: List[Tuple[Dict[str, Any], Dict[str, Any], str, Any]] = []
         for tool in tools:
             if not isinstance(tool, dict):
                 continue
@@ -898,18 +927,32 @@ class ToolSampler:
                 continue
             if self._payload_has_error_markers(sample_payload):
                 continue
+            candidates.append((tool, function, str(tool_name), sample_payload))
 
-            derived_schema = await self._derive_output_schema_from_sample_with_llm(
-                tool_name=str(tool_name),
-                tool_description=function.get("description") or tool.get("description"),
-                input_schema=function.get("parameters")
-                or tool.get("inputSchema")
-                or {},
-                sample_payload=sample_payload,
+        if not candidates:
+            return tools, 0
+
+        derived_schemas = await asyncio.gather(
+            *(
+                self._derive_output_schema_from_sample_with_llm(
+                    tool_name=tool_name,
+                    tool_description=function.get("description")
+                    or tool.get("description"),
+                    input_schema=function.get("parameters")
+                    or tool.get("inputSchema")
+                    or {},
+                    sample_payload=sample_payload,
+                )
+                for tool, function, tool_name, sample_payload in candidates
             )
+        )
+
+        derived_count = 0
+        for (tool, function, _tool_name, _sample), derived_schema in zip(
+            candidates, derived_schemas
+        ):
             if not derived_schema:
                 continue
-
             tool["outputSchema"] = derived_schema
             if isinstance(function, dict):
                 function["outputSchema"] = derived_schema


### PR DESCRIPTION
Improved patching, dummy data reuse and sse handling.

## Notes for reviewers

- **Behavior change:** failed phase-1 attempt reasons now carry forward as a compact summary into the next retry's messages (previously each retry started from a pristine message list, discarding failure context). This is a deliberate change from the prior "cleanly discard failed attempts" approach — it lets the model self-correct instead of repeating the same mistake blind.
- **Vendored/test-infra diff:** `domstubs.js` (+/- ~2600 lines) and `pfusch.js` (+170/-1) are a de-minified/reformatted copy of vendored test helpers, not owned logic changes — included for readability of future diffs against them, not part of this PR's functional scope.
