### PR TITLE
feat(observability): record user.id and execution_id on the chat span

### DIFF
--- a/app/tgi/routes.py
+++ b/app/tgi/routes.py
@@ -1,4 +1,5 @@
 import asyncio
+import jwt
 import logging
 import os
 from datetime import datetime, timezone
@@ -22,7 +23,6 @@ from app.utils.traced_requests import traced_request
 from app.session import try_get_session_id, session_id
 from app.session_manager import mcp_session_context, session_manager
 from app.oauth.token_exchange import UserLoggedOutException
-from app.oauth.user_info import UserInfoExtractor
 from app.utils.exception_logging import (
     find_exception_in_exception_groups,
     log_exception_with_details,
@@ -105,7 +105,12 @@ def _resolve_user_id_for_tracing(user_token: Optional[str]) -> Optional[str]:
     if not user_token:
         return None
     try:
-        return UserInfoExtractor().extract_user_info(user_token).get("sub")
+        payload = jwt.decode(
+            user_token,
+            options={"verify_signature": False},
+            algorithms=["RS256", "HS256"],
+        )
+        return payload.get("sub")
     except Exception as exc:
         logger.debug(f"[TGI] Could not resolve user.id for tracing: {exc}")
         return None

--- a/app/tgi/routes.py
+++ b/app/tgi/routes.py
@@ -22,6 +22,7 @@ from app.utils.traced_requests import traced_request
 from app.session import try_get_session_id, session_id
 from app.session_manager import mcp_session_context, session_manager
 from app.oauth.token_exchange import UserLoggedOutException
+from app.oauth.user_info import UserInfoExtractor
 from app.utils.exception_logging import (
     find_exception_in_exception_groups,
     log_exception_with_details,
@@ -97,6 +98,17 @@ def _resolve_user_token(
 ) -> Optional[str]:
     header_name = TOKEN_NAME.lower()
     return incoming_headers.get(header_name) or access_token
+
+
+def _resolve_user_id_for_tracing(user_token: Optional[str]) -> Optional[str]:
+    """Best-effort caller id for telemetry. Never breaks the chat request."""
+    if not user_token:
+        return None
+    try:
+        return UserInfoExtractor().extract_user_info(user_token).get("sub")
+    except Exception as exc:
+        logger.debug(f"[TGI] Could not resolve user.id for tracing: {exc}")
+        return None
 
 
 def _header_truthy(value: Optional[str]) -> bool:
@@ -354,7 +366,8 @@ async def _handle_chat_completion(
             "chat.model": chat_request.model,
             "chat.prompt_requested": prompt or "",
         },
-    ):
+        user_id=_resolve_user_id_for_tracing(user_token),
+    ) as span:
         done_sent = False
         try:
             if (
@@ -366,6 +379,7 @@ async def _handle_chat_completion(
                 if not chat_request.workflow_execution_id:
                     chat_request.workflow_execution_id = str(uuid4())
                 execution_id = chat_request.workflow_execution_id
+                span.set_attribute("execution_id", execution_id)
 
                 copier = getattr(chat_request, "model_copy", None)
                 background_request = (

--- a/app/tgi/test_routes_tracing.py
+++ b/app/tgi/test_routes_tracing.py
@@ -128,6 +128,8 @@ async def test_chat_span_records_user_id_and_execution_id(monkeypatch, fake_trac
         key="test-secret-key-long-enough-for-hs256",
         algorithm="HS256",
     )
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
     request = _make_request(
         {
             "Accept": "text/event-stream",

--- a/app/tgi/test_routes_tracing.py
+++ b/app/tgi/test_routes_tracing.py
@@ -1,0 +1,180 @@
+import asyncio
+
+import jwt
+import pytest
+from starlette.requests import Request
+
+from app.tgi.models import ChatCompletionRequest, Message, MessageRole
+from app.tgi.routes import _handle_chat_completion
+from app.tgi.workflows.models import WorkflowExecutionState
+
+
+@pytest.fixture(autouse=True)
+def _set_tgi_url(monkeypatch):
+    monkeypatch.setenv("TGI_URL", "https://api.test-llm.com/v1")
+    monkeypatch.setenv("TGI_TOKEN", "test-token-123")
+
+
+class _FakeSpan:
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class _FakeTracer:
+    """Minimal stand-in for an opentelemetry Tracer, recording set_attribute calls."""
+
+    def __init__(self):
+        self.span = _FakeSpan()
+
+    def start_as_current_span(self, name):
+        return self
+
+    def __enter__(self):
+        return self.span
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def fake_tracer(monkeypatch):
+    tracer = _FakeTracer()
+    monkeypatch.setattr("app.tgi.routes.tracer", tracer)
+    return tracer
+
+
+def _make_request(headers: dict[str, str]) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/tgi/v1/chat/completions",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+    }
+    return Request(scope)
+
+
+class _StubStateStore:
+    def __init__(self, state: WorkflowExecutionState):
+        self._state = state
+
+    def load_execution(self, execution_id: str):
+        return self._state
+
+
+class _StubEngine:
+    def __init__(self, state: WorkflowExecutionState):
+        self.state_store = _StubStateStore(state)
+
+    def _enforce_workflow_owner(self, state: WorkflowExecutionState, user_token: str):
+        pass
+
+
+class _StubBackground:
+    def __init__(self, queue_items: list[tuple[int, str, bool]]):
+        self.queue_items = queue_items
+        self.started = False
+
+    async def get_or_start(self, execution_id, stream_factory, initial_event_count=0):
+        self.started = True
+        return None
+
+    async def __aenter__(self):
+        queue: asyncio.Queue = asyncio.Queue()
+        for item in self.queue_items:
+            await queue.put(item)
+        await queue.put((0, None, False))
+        return queue
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def subscribe(self, execution_id):
+        return self
+
+    def is_running(self, execution_id: str) -> bool:
+        return False
+
+
+def _looping_chat_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        messages=[Message(role=MessageRole.USER, content="New message")],
+        stream=True,
+        use_workflow="flow",
+    )
+
+
+def _setup_workflow_service(monkeypatch) -> _StubBackground:
+    state = WorkflowExecutionState.new("exec-1", "flow")
+    state.context["_workflow_loop"] = True
+    engine = _StubEngine(state)
+    background = _StubBackground([(0, "data: submitted\n\n", False)])
+
+    class _StubService:
+        workflow_engine = engine
+        workflow_background = background
+
+    monkeypatch.setattr("app.tgi.routes.tgi_service", _StubService())
+    return background
+
+
+@pytest.mark.asyncio
+async def test_chat_span_records_user_id_and_execution_id(monkeypatch, fake_tracer):
+    background = _setup_workflow_service(monkeypatch)
+    token = jwt.encode(
+        {"sub": "user-42"},
+        key="test-secret-key-long-enough-for-hs256",
+        algorithm="HS256",
+    )
+    request = _make_request(
+        {
+            "Accept": "text/event-stream",
+            "x-inxm-workflow-background": "true",
+            "X-Auth-Request-Access-Token": token,
+        }
+    )
+    chat_request = _looping_chat_request()
+
+    chunks = [
+        chunk
+        async for chunk in _handle_chat_completion(
+            request, chat_request, None, None, None, None
+        )
+    ]
+
+    assert background.started is True
+    assert "[DONE]" in chunks[-1]
+
+    attributes = fake_tracer.span.attributes
+    assert attributes.get("user.id") == "user-42"
+    assert chat_request.workflow_execution_id
+    assert attributes.get("execution_id") == chat_request.workflow_execution_id
+
+
+@pytest.mark.asyncio
+async def test_chat_span_omits_user_id_when_token_undecodable(monkeypatch, fake_tracer):
+    background = _setup_workflow_service(monkeypatch)
+    request = _make_request(
+        {
+            "Accept": "text/event-stream",
+            "x-inxm-workflow-background": "true",
+            "X-Auth-Request-Access-Token": "not-a-valid-jwt",
+        }
+    )
+    chat_request = _looping_chat_request()
+
+    chunks = [
+        chunk
+        async for chunk in _handle_chat_completion(
+            request, chat_request, None, None, None, None
+        )
+    ]
+
+    assert background.started is True
+    assert "[DONE]" in chunks[-1]
+
+    attributes = fake_tracer.span.attributes
+    assert "user.id" not in attributes
+    assert attributes.get("execution_id") == chat_request.workflow_execution_id

--- a/app/utils/test_traced_requests.py
+++ b/app/utils/test_traced_requests.py
@@ -1,0 +1,54 @@
+from app.utils.traced_requests import traced_request
+
+
+class _FakeSpan:
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.span = _FakeSpan()
+
+    def start_as_current_span(self, name):
+        return self
+
+    def __enter__(self):
+        return self.span
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_traced_request_sets_user_id_when_present():
+    tracer = _FakeTracer()
+
+    with traced_request(
+        tracer=tracer,
+        operation="op",
+        session_value="session-1",
+        group=None,
+        start_message="starting",
+        user_id="user-42",
+    ):
+        pass
+
+    assert tracer.span.attributes.get("user.id") == "user-42"
+
+
+def test_traced_request_omits_user_id_when_absent():
+    tracer = _FakeTracer()
+
+    with traced_request(
+        tracer=tracer,
+        operation="op",
+        session_value="session-1",
+        group=None,
+        start_message="starting",
+    ):
+        pass
+
+    assert "user.id" not in tracer.span.attributes

--- a/app/utils/traced_requests.py
+++ b/app/utils/traced_requests.py
@@ -17,6 +17,7 @@ def traced_request(
     group: Optional[str],
     start_message: str,
     extra_attrs: Optional[Dict] = None,
+    user_id: Optional[str] = None,
 ):
     """Context manager to create a span, set common attributes, and log a start message."""
     with tracer.start_as_current_span(operation) as span:
@@ -24,6 +25,8 @@ def traced_request(
             span.set_attribute("session.id", session_value)
         if group:
             span.set_attribute("session.group", group)
+        if user_id:
+            span.set_attribute("user.id", user_id)
         if extra_attrs:
             for k, v in extra_attrs.items():
                 span.set_attribute(k, v)


### PR DESCRIPTION
## Summary
- Adds an optional `user_id` param to `traced_request` (`app/utils/traced_requests.py`), setting `user.id` on the span only when present — consistent with the existing `session_value`/`group` params.
- Binds the chat span in `_handle_chat_completion` (`app/tgi/routes.py`) `as span`, resolves the caller's `sub` claim defensively via a new `_resolve_user_id_for_tracing` helper (swallows decode failures, logs at debug, never raises), and passes it to `traced_request`.
- Once `chat_request.workflow_execution_id` is resolved/minted in the background-workflow path, records `execution_id` on the same span (skipped for one-off requests that never mint one).

This completes the trace-identifier trio at the bridge's chat entry point — `session.id` was already recorded; `user.id` and `execution_id` (both known/minted here) now join it, matching the attribute naming used across the orchestrator, app-airflow, and app-tgi-core for cross-service Jaeger search.

**Span emitting these attributes:** the `chat_completions` span created in `_handle_chat_completion` (`app/tgi/routes.py`).

## Out of scope (per issue)
- Threading `user_id` into other `traced_request` callers (start_session, close_session, tool/prompt calls) — only the optional param was added so they *can* adopt it later.
- No `plan_id`, no auth/token-exchange/routing changes, no JWT signature verification.

## Test plan
- [x] `pytest app/utils/test_traced_requests.py app/tgi/test_routes_tracing.py app/tgi/test_tgi_background_routes.py app/tgi/test_routes.py` — new + adjacent tests pass
- [x] `pytest -m "not integration"` — full non-integration suite: 1360 passed (one pre-existing, unrelated `uvicorn`-subprocess environment failure in `test_token_cookie.py`, not touched by this change)
- [x] `black --check` clean on touched files

Closes https://github.com/inxm-ai/enterprise-mcp-bridge/issues/83

🤖 Generated with [Claude Code](https://claude.com/claude-code)