### PR TITLE
fix(routes): report tool execution errors as 422, not 500

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -64,6 +64,11 @@ _USER_FEEDBACK_KEY_RE = re.compile(r"^_?user_feedback$", re.IGNORECASE)
 # bridge is unhealthy, retrying may help".
 HTTP_STATUS_TOOL_EXECUTION_ERROR = 422
 
+# An upstream service the tool depends on did not answer in time. Unlike a
+# tool execution error this is transient, so it must stay in the 5xx class
+# that callers treat as retryable.
+HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT = 504
+
 tracer = trace.get_tracer(__name__)
 
 if MCP_BASE_PATH:
@@ -497,6 +502,18 @@ async def run_tool(
                     f"[Tool-Call] Tool called with invalid parameters: {tool_name}. Result: {result}"
                 )
                 raise HTTPException(status_code=400, detail=str(result))
+
+            # Timeouts are transient: the same call may succeed on retry, so
+            # they must not fall into the terminal 4xx bucket below. FastMCP
+            # flattens the exception class to prose, so the text is all we
+            # have to classify on.
+            if "timed out" in error_text.lower():
+                logger.warning(
+                    f"[Tool-Call] Upstream timeout in tool {tool_name}: {result}"
+                )
+                raise HTTPException(
+                    status_code=HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT, detail=str(result)
+                )
 
             # The tool ran and rejected the request; the bridge itself is healthy.
             # 4xx keeps callers from retrying a failure that cannot succeed.

--- a/app/routes.py
+++ b/app/routes.py
@@ -59,6 +59,11 @@ sessions = session_manager()
 logger = logging.getLogger("uvicorn.error")
 _USER_FEEDBACK_KEY_RE = re.compile(r"^_?user_feedback$", re.IGNORECASE)
 
+# A tool that ran and returned isError is not a bridge fault. Reporting it as
+# 4xx lets callers distinguish "this request will never succeed" from "the
+# bridge is unhealthy, retrying may help".
+HTTP_STATUS_TOOL_EXECUTION_ERROR = 422
+
 tracer = trace.get_tracer(__name__)
 
 if MCP_BASE_PATH:
@@ -483,17 +488,22 @@ async def run_tool(
 
         logger.info(f"[Tool-Call] Tool {tool_name} called. Result: {result}")
         if result.isError:
-            if "Unknown tool" in result.content[0].text:
+            error_text = result.content[0].text if result.content else ""
+            if "Unknown tool" in error_text:
                 logger.info(f"[Tool-Call] Tool not found: {tool_name}")
                 raise HTTPException(status_code=404, detail=str(result))
-            if "validation error" in result.content[0].text:
+            if "validation error" in error_text:
                 logger.info(
                     f"[Tool-Call] Tool called with invalid parameters: {tool_name}. Result: {result}"
                 )
                 raise HTTPException(status_code=400, detail=str(result))
 
+            # The tool ran and rejected the request; the bridge itself is healthy.
+            # 4xx keeps callers from retrying a failure that cannot succeed.
             logger.error(f"[Tool-Call] Error in tool {tool_name}: {result}")
-            raise HTTPException(status_code=500, detail=str(result))
+            raise HTTPException(
+                status_code=HTTP_STATUS_TOOL_EXECUTION_ERROR, detail=str(result)
+            )
         return result
     except ElicitationRequiredError as e:
         raise HTTPException(status_code=409, detail=e.to_client_payload())

--- a/app/test_routes_tool_error_status.py
+++ b/app/test_routes_tool_error_status.py
@@ -2,7 +2,10 @@ import pytest
 from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
 from app.server import app as fastapi_app
-from app.routes import HTTP_STATUS_TOOL_EXECUTION_ERROR
+from app.routes import (
+    HTTP_STATUS_TOOL_EXECUTION_ERROR,
+    HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT,
+)
 from pydantic import BaseModel
 
 
@@ -57,6 +60,34 @@ def test_tool_execution_error_is_client_error_not_server_error(
     assert response.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR
     assert 400 <= response.status_code < 500
     assert "Max 20 URLs are allowed." in response.json()["detail"]
+
+
+def test_upstream_timeout_stays_retryable(client, mock_session_context):
+    """A timeout is transient — the same call may succeed on retry.
+
+    It must map to 5xx (504), never the terminal 4xx bucket: callers route
+    4xx to a no-retry failure, which would kill the task over a blip.
+    """
+    response = _call_failing_tool(
+        client,
+        mock_session_context,
+        # tavily-python's TimeoutError text, as flattened by FastMCP.
+        "Error executing tool crawl: Request timed out after 60 seconds.",
+    )
+
+    assert response.status_code == HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT
+    assert response.status_code >= 500
+    assert "timed out" in response.json()["detail"]
+
+
+def test_timeout_detection_is_case_insensitive(client, mock_session_context):
+    response = _call_failing_tool(
+        client,
+        mock_session_context,
+        "Error executing tool fetch: Timed Out waiting for upstream.",
+    )
+
+    assert response.status_code == HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT
 
 
 def test_unknown_tool_still_maps_to_404(client, mock_session_context):

--- a/app/test_routes_tool_error_status.py
+++ b/app/test_routes_tool_error_status.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from app.server import app as fastapi_app
+from app.routes import HTTP_STATUS_TOOL_EXECUTION_ERROR
+from pydantic import BaseModel
+
+
+class MockContent(BaseModel):
+    text: str
+    type: str = "text"
+    structuredContent: dict | None = None
+
+
+class MockResult(BaseModel):
+    content: list[MockContent]
+    isError: bool = False
+    structuredContent: dict | None = None
+
+
+@pytest.fixture
+def client():
+    return TestClient(fastapi_app)
+
+
+@pytest.fixture
+def mock_session_context():
+    with patch("app.routes.mcp_session_context") as mock_ctx:
+        mock_session = AsyncMock()
+        mock_ctx.return_value.__aenter__.return_value = mock_session
+        yield mock_session
+
+
+def _call_failing_tool(client, mock_session_context, text):
+    mock_session_context.call_tool.return_value = MockResult(
+        content=[MockContent(text=text)], isError=True
+    )
+    return client.post(
+        "/tools/test_tool", headers={"x-inxm-mcp-session": "test-session"}, json={}
+    )
+
+
+def test_tool_execution_error_is_client_error_not_server_error(
+    client, mock_session_context
+):
+    """A tool that ran and rejected the request must not look like a bridge fault.
+
+    Callers key their retry decision off the status class, so a deterministic
+    failure reported as 5xx gets retried until the budget is gone.
+    """
+    response = _call_failing_tool(
+        client,
+        mock_session_context,
+        "Error executing tool search_social_media: Max 20 URLs are allowed.",
+    )
+
+    assert response.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR
+    assert 400 <= response.status_code < 500
+    assert "Max 20 URLs are allowed." in response.json()["detail"]
+
+
+def test_unknown_tool_still_maps_to_404(client, mock_session_context):
+    response = _call_failing_tool(
+        client, mock_session_context, "Unknown tool: nope_tool"
+    )
+
+    assert response.status_code == 404
+
+
+def test_validation_error_still_maps_to_400(client, mock_session_context):
+    response = _call_failing_tool(
+        client, mock_session_context, "1 validation error for test_tool"
+    )
+
+    assert response.status_code == 400
+
+
+def test_error_result_with_empty_content_does_not_crash(client, mock_session_context):
+    """An isError result carrying no content used to raise IndexError, which the
+    outer handler turned into a generic 500 that discarded the real error."""
+    mock_session_context.call_tool.return_value = MockResult(content=[], isError=True)
+
+    response = client.post(
+        "/tools/test_tool", headers={"x-inxm-mcp-session": "test-session"}, json={}
+    )
+
+    assert response.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR

--- a/app/utils_tests/fastapi_wrapper.py
+++ b/app/utils_tests/fastapi_wrapper.py
@@ -147,9 +147,13 @@ class FastAPIWrapper:
         ), f"Unexpected status code: {r.status_code}, Response: {r.text}"
 
     def test_tool_error(self):
+        from app.routes import HTTP_STATUS_TOOL_EXECUTION_ERROR
+
         r = self.client.post(f"{self.base_url}/tools/error", json={"message": "fail!"})
+        # A tool that ran and raised is a client-side problem, not a bridge fault:
+        # retrying the same request can never succeed.
         assert (
-            r.status_code >= 500
+            r.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR
         ), f"Unexpected status code: {r.status_code}, Response: {r.text}"
 
     def test_parallel_calls(self):


### PR DESCRIPTION
## Why

A tool that ran and returned `isError` is not a bridge fault, but `run_tool` mapped every unrecognised tool error to **500**.

Callers key their retry decision off the status class, so a deterministic failure — bad arguments, an upstream API rejecting the request — got retried until the budget ran out, with each attempt re-paying for the work that had already succeeded.

Observed on QA: `mcp-tavily-server`'s `search_social_media` exceeded Tavily's 20-URL `/extract` cap. That surfaced as a 500, which made `app-airflow` raise `ValueError` (retryable) instead of `AirflowFailException` (terminal):

```python
# app-airflow pkgs/inxm_steps/inxm_steps_v1/__init__.py:618
if status_code is not None and 400 <= status_code < 500:
    raise AirflowFailException(...)   # not retried
raise ValueError(...)                 # retried
```

## What changed

- Tool-execution errors now return **422** via a named `HTTP_STATUS_TOOL_EXECUTION_ERROR` constant.
- **Upstream timeouts return 504**, not 422 (`HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT`). A timeout is transient — the same call may succeed on retry — so it must not fall into the terminal 4xx bucket. Without this, the 422 change would have *regressed* timeouts: today's blanket 500 got them retried by accident; 422 would have killed the task over a blip. Observed on QA with a slow Tavily upstream.
- `404` (unknown tool) and `400` (validation error) mappings are unchanged.
- Status classes now read: `422` = tool rejected the request, terminal; `504` = upstream slow, retryable; `500` = bridge fault, retryable.
- Guarded `result.content[0]` on the error path. An `isError` result with empty content raised `IndexError`, which the outer handler turned into a generic `500 "Internal server error"` that **discarded the real error text**. `content_resolver` in `models.py` already defends against this; the route did not.

## Consumer impact

**No caller changes needed.** `app-airflow` already routes 4xx to `AirflowFailException`, so this alone fixes the retry waste.

**The agentic path is unaffected.** TGI calls `session.call_tool` directly (`app/tgi/services/tool_service.py:440`) and never goes through this HTTP route, so it never saw these statuses.

## Why 422 rather than 200 + `isError`

Strict MCP semantics put execution errors in-band — and `RunToolsResult` already models `isError` as a first-class field, so the schema is built for it. But `inxm_steps` has **zero** references to `isError` and validates purely on `response.raise_for_status()`. Flipping to `200 + isError=true` today would make app-airflow read a failed tool call as **success** and pass the error text downstream as if it were data — trading a loud wrong failure for a silent wrong success.

That move stays open, but it needs a coordinated two-repo landing. 422 gets the retry fix now, in one repo, with no coordination.

## Verification

```bash
pytest app/ -m "not integration"
```

`1445 passed`, against a `1439 passed` baseline on clean `origin/main`. The one remaining failure (`test_generated_service.py::test_iterative_test_fix_resets_attempts_on_progress`) fails identically on clean `origin/main` — pre-existing, unrelated. `black --check` clean on all three changed files.

New `app/test_routes_tool_error_status.py` covers the 422 mapping, the 504 timeout mapping (including case-insensitivity), the preserved 404/400 mappings, and the empty-content crash.

`app/utils_tests/fastapi_wrapper.py::test_tool_error` asserted `status_code >= 500`; updated to the new contract. It exercises a real MCP tool that raises, so it is the end-to-end proof of the change — it is shared by both `test_app.py` and `test_fastapi_with_testclient.py`.

## Related

Paired with inxm-ai/mcp-tavily-server#7, which fixes the specific tool that triggered this. Independent changes — either can land alone.

## Notes

- `detail=str(result)` is left as-is: it serialises a Python repr (`isError=True content=[RunToolResultContent(text='...')]`) that no caller can parse. Worth making a structured dict, but that changes the response contract for the 404/400/422 paths and belongs in its own change.
- Classification still works by string-matching the error text (`"Unknown tool"`, `"validation error"`, now `"timed out"`), so the bridge cannot reliably distinguish *upstream rejected our input* from *upstream is down* from *the tool has a bug* — the timeout pattern is the third instance of this accreting. The real fix is for tools to signal error class as data; FastMCP flattens every exception to a string today.
- The fallback for unclassified errors is 422, which relabels genuine tool *crashes* (e.g. a NameError in tool code) as client errors and takes them out of 5xx-based alerting. Deliberate trade-off per review: retry-correctness for the common case won over alert visibility for the rare one. If a tool-bug class emerges that needs paging, it wants the errors-as-data fix above, not another string pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
