### PR TITLE
feat(routes): add GET /healthz/child startup-probe endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -136,7 +136,20 @@ async def healthz_child():
             status_code=503,
             detail="child MCP server failed to start or list tools",
         )
-    tool_count = len(getattr(tools, "tools", None) or [])
+    # list_tools() returns either a container with `.tools` or an iterable
+    # directly (see session_context._to_tool_list). Anything else must fail
+    # the probe rather than count as zero tools and go green.
+    raw_tools = getattr(tools, "tools", tools)
+    try:
+        tool_count = len(list(raw_tools)) if raw_tools is not None else 0
+    except TypeError:
+        logger.error(
+            "[Healthz-Child] Unexpected list_tools result shape: %r", type(tools)
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="child MCP server returned a malformed tools list",
+        )
     return {"status": "ok", "tools": tool_count}
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -25,6 +25,7 @@ from app.utils.traced_requests import traced_request
 from app.utils.structured_text_parser import try_parse_structured_text
 from app.session import (
     MCPLocalSessionTask,
+    mcp_session,
     try_get_session_id,
     session_id,
     build_mcp_client_strategy,
@@ -116,6 +117,27 @@ async def home():
     if APP_CONVERSATIONAL_UI_ENABLED:
         result["urls"]["conversational_ui"] = "/app/_generated/start"
     return result
+
+
+@router.get("/healthz/child")
+async def healthz_child():
+    """Startup-probe target proving the child MCP server actually works.
+
+    Opens a fresh anonymous MCP session and lists tools — the two steps that
+    fail when inline-code deps are wrong. Pass/fail only: the child's
+    traceback already lands in pod logs, so no stderr plumbing here.
+    """
+    try:
+        async with mcp_session(anon=True) as session:
+            tools = await session.list_tools()
+    except Exception as e:
+        log_exception_with_details(logger, "[Healthz-Child]", e)
+        raise HTTPException(
+            status_code=503,
+            detail="child MCP server failed to start or list tools",
+        )
+    tool_count = len(getattr(tools, "tools", None) or [])
+    return {"status": "ok", "tools": tool_count}
 
 
 @router.get("/resources")

--- a/app/test_routes_healthz_child.py
+++ b/app/test_routes_healthz_child.py
@@ -1,0 +1,55 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes import healthz_child
+
+
+@pytest.mark.asyncio
+async def test_healthz_child_reports_tool_count_when_child_works():
+    async def list_tools():
+        return SimpleNamespace(tools=[object(), object(), object()])
+
+    @asynccontextmanager
+    async def working_session(**kwargs):
+        yield SimpleNamespace(list_tools=list_tools)
+
+    with patch("app.routes.mcp_session", working_session):
+        result = await healthz_child()
+
+    assert result == {"status": "ok", "tools": 3}
+
+
+@pytest.mark.asyncio
+async def test_healthz_child_returns_503_when_child_fails_to_start():
+    @asynccontextmanager
+    async def broken_session(**kwargs):
+        raise RuntimeError(
+            "ImportError: cannot import name 'streamablehttp_client' (mcp==2.0.0)"
+        )
+        yield  # pragma: no cover
+
+    with patch("app.routes.mcp_session", broken_session):
+        with pytest.raises(HTTPException) as exc_info:
+            await healthz_child()
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_healthz_child_returns_503_when_list_tools_fails():
+    async def list_tools():
+        raise RuntimeError("child session opened but tools are broken")
+
+    @asynccontextmanager
+    async def session_with_broken_tools(**kwargs):
+        yield SimpleNamespace(list_tools=list_tools)
+
+    with patch("app.routes.mcp_session", session_with_broken_tools):
+        with pytest.raises(HTTPException) as exc_info:
+            await healthz_child()
+
+    assert exc_info.value.status_code == 503

--- a/app/test_routes_healthz_child.py
+++ b/app/test_routes_healthz_child.py
@@ -24,6 +24,37 @@ async def test_healthz_child_reports_tool_count_when_child_works():
 
 
 @pytest.mark.asyncio
+async def test_healthz_child_counts_plain_list_returns():
+    async def list_tools():
+        return [object(), object()]
+
+    @asynccontextmanager
+    async def working_session(**kwargs):
+        yield SimpleNamespace(list_tools=list_tools)
+
+    with patch("app.routes.mcp_session", working_session):
+        result = await healthz_child()
+
+    assert result == {"status": "ok", "tools": 2}
+
+
+@pytest.mark.asyncio
+async def test_healthz_child_returns_503_on_malformed_tools_result():
+    async def list_tools():
+        return 42
+
+    @asynccontextmanager
+    async def session_with_malformed_tools(**kwargs):
+        yield SimpleNamespace(list_tools=list_tools)
+
+    with patch("app.routes.mcp_session", session_with_malformed_tools):
+        with pytest.raises(HTTPException) as exc_info:
+            await healthz_child()
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
 async def test_healthz_child_returns_503_when_child_fails_to_start():
     @asynccontextmanager
     async def broken_session(**kwargs):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -46,6 +46,28 @@ Health check endpoint.
 
 ---
 
+#### GET /healthz/child
+
+Deep health check proving the child MCP server works: opens a fresh
+anonymous MCP session and calls `list_tools()`. Intended as a Kubernetes
+startup probe target for inline-code deployments, where broken Python
+dependencies would otherwise leave the pod Ready while every session
+spawn fails. Pass/fail only — the child's traceback lands in pod logs.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "tools": 5
+}
+```
+
+**Status Codes:**
+- `200 OK` - Child server started and listed its tools
+- `503 Service Unavailable` - Child failed to start, list tools, or returned a malformed tools list
+
+---
+
 #### GET /
 
 Root endpoint with service information.


### PR DESCRIPTION
Piece 1 of inxm-ai/app-mcp-manager#52.

Inline-code deployments pip-install their deps at pod init; when they're wrong, the bridge still binds :8000 and TCP probes report the pod Ready while every session spawn fails (mcp 2.0.0 incident).

**`GET /healthz/child`** opens a fresh anonymous `mcp_session` and calls `list_tools()` — the exact path a bad dep breaks:

- `200 {"status": "ok", "tools": <count>}`
- `503` on session-spawn failure, list_tools failure, or a malformed tools result

Pass/fail only by design; the child's traceback lands in pod logs. Served under `MCP_BASE_PATH` like every other route. Documented in `docs/reference/api.md`.

**Deploy ordering:** must be in the deployed bridge image before app-mcp-manager#53 points a startupProbe at it.

Tests: success (container + plain-list shapes), spawn failure, list_tools failure, malformed result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)