### PR TITLE
fix(remote-mcp): bound transport teardown with anyio shield

### DIFF
--- a/app/session/client_strategy.py
+++ b/app/session/client_strategy.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import os
@@ -8,6 +7,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from typing import AsyncIterator, Optional
 from urllib.parse import urlparse
 
+import anyio
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.stdio import stdio_client
@@ -35,6 +35,7 @@ from app.vars import (
     MCP_REMOTE_REDIRECT_URI,
     MCP_REMOTE_SCOPE,
     MCP_REMOTE_SERVER,
+    MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS,
 )
 
 logger = logging.getLogger("uvicorn.error")
@@ -403,7 +404,6 @@ class RemoteMCPClientStrategy(MCPClientStrategy):
         # SSE endpoints typically end with /sse or only support GET+SSE
         use_sse_only = self.url.endswith("/sse")
         stack = AsyncExitStack()
-        cancelled = False
         try:
             if use_sse_only:
                 logger.info(
@@ -448,15 +448,22 @@ class RemoteMCPClientStrategy(MCPClientStrategy):
             if get_session_id:
                 setattr(session, "get_remote_session_id", get_session_id)
             yield session
-        except asyncio.CancelledError:
-            cancelled = True
-            raise
         finally:
+            # Close under an anyio shield, never asyncio.shield: the transports
+            # are anyio task groups, and an uncancellable asyncio future inside
+            # a cancelled anyio scope makes _deliver_cancellation respin every
+            # event-loop tick, pinning the CPU for the life of the process.
+            # The timeout guarantees the scope exits even if teardown hangs.
             try:
-                if cancelled:
-                    await asyncio.shield(stack.aclose())
-                else:
+                with anyio.move_on_after(
+                    MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS, shield=True
+                ) as teardown_scope:
                     await stack.aclose()
+                if teardown_scope.cancelled_caught:
+                    logger.warning(
+                        "[RemoteMCP] Transport teardown timed out after "
+                        f"{MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS}s; abandoning close"
+                    )
             except Exception as exc:
                 logger.debug(f"[RemoteMCP] Error while closing transport: {exc}")
 

--- a/app/session/test_client_strategy.py
+++ b/app/session/test_client_strategy.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from contextlib import asynccontextmanager
 
 import pytest
@@ -511,10 +512,15 @@ async def test_remote_strategy_teardown_bounded_when_close_hangs(monkeypatch):
             task.cancel()
             await asyncio.sleep(0)
 
+    started = time.monotonic()
     with pytest.raises(asyncio.CancelledError):
         # wait_for bounds the test itself: without the teardown timeout this
         # hangs forever instead of failing an assertion.
         await asyncio.wait_for(asyncio.shield(cancelled_session()), timeout=5)
+    elapsed = time.monotonic() - started
+    # 10x the 0.1s teardown timeout as scheduling tolerance: asserts the
+    # configured bound is honored, not merely that we exit before wait_for.
+    assert elapsed < 1.0, f"teardown took {elapsed:.2f}s, expected ~0.1s"
 
 
 @pytest.mark.asyncio

--- a/app/session/test_client_strategy.py
+++ b/app/session/test_client_strategy.py
@@ -468,6 +468,56 @@ async def test_remote_strategy_closes_on_cancellation(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_remote_strategy_teardown_bounded_when_close_hangs(monkeypatch):
+    """A transport whose close never returns must not wedge the session exit.
+
+    Regression test for the anyio _deliver_cancellation busy-loop: cancelling a
+    request while the remote transport hangs in __aexit__ used to leave the
+    event loop spinning forever. Teardown must give up after the configured
+    timeout and let the cancellation propagate.
+    """
+
+    class HangingStreamableContext:
+        async def __aenter__(self):
+            return object(), object(), lambda: None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await asyncio.Event().wait()
+
+    def fake_streamable_client(url, headers=None, auth=None):
+        return HangingStreamableContext()
+
+    monkeypatch.setattr(
+        client_strategy, "streamablehttp_client", fake_streamable_client
+    )
+    monkeypatch.setattr(client_strategy, "ClientSession", DummyClientSession)
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_SERVER", "https://remote.example")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_SCOPE", "")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_REDIRECT_URI", "")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_CLIENT_ID", "")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_CLIENT_SECRET", "")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_BEARER_TOKEN", "static-token")
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setenv("MCP_SERVER_COMMAND", "")
+
+    strategy = client_strategy.build_mcp_client_strategy(
+        access_token=None, requested_group=None
+    )
+
+    async def cancelled_session():
+        async with strategy.session():
+            task = asyncio.current_task()
+            assert task is not None
+            task.cancel()
+            await asyncio.sleep(0)
+
+    with pytest.raises(asyncio.CancelledError):
+        # wait_for bounds the test itself: without the teardown timeout this
+        # hangs forever instead of failing an assertion.
+        await asyncio.wait_for(asyncio.shield(cancelled_session()), timeout=5)
+
+
+@pytest.mark.asyncio
 async def test_remote_strategy_custom_auth_header_name_and_template(monkeypatch):
     """Provider token lands in a custom header without a Bearer prefix."""
 
@@ -547,9 +597,7 @@ async def test_remote_strategy_custom_auth_header_fallback_token(monkeypatch):
 
 
 def test_format_auth_header_value_default(monkeypatch):
-    monkeypatch.setattr(
-        client_strategy, "MCP_REMOTE_AUTH_HEADER_VALUE_TEMPLATE", ""
-    )
+    monkeypatch.setattr(client_strategy, "MCP_REMOTE_AUTH_HEADER_VALUE_TEMPLATE", "")
     assert (
         client_strategy.RemoteMCPClientStrategy._format_auth_header_value("tok")
         == "Bearer tok"

--- a/app/vars.py
+++ b/app/vars.py
@@ -194,12 +194,15 @@ MCP_REMOTE_CLIENT_ID = os.getenv("MCP_REMOTE_CLIENT_ID", "")
 MCP_REMOTE_CLIENT_SECRET = os.getenv("MCP_REMOTE_CLIENT_SECRET", "")
 MCP_REMOTE_BEARER_TOKEN = os.getenv("MCP_REMOTE_BEARER_TOKEN", "")
 MCP_REMOTE_ANON_BEARER_TOKEN = os.getenv("MCP_REMOTE_ANON_BEARER_TOKEN", "")
+# Upper bound on remote transport teardown. An unbounded close wedged inside a
+# cancelled scope busy-loops anyio's cancellation delivery (permanent CPU spin).
+MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS = float(
+    os.getenv("MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS", "10")
+)
 # Header carrying the auth token towards the remote MCP server. Gateways like
 # Azure APIM behind an ESB may expect the credential in a custom header (e.g.
 # esb-subscription-key) instead of Authorization.
-MCP_REMOTE_AUTH_HEADER_NAME = os.getenv(
-    "MCP_REMOTE_AUTH_HEADER_NAME", "Authorization"
-)
+MCP_REMOTE_AUTH_HEADER_NAME = os.getenv("MCP_REMOTE_AUTH_HEADER_NAME", "Authorization")
 # Format of the auth header value. Placeholders: {token}, {token_type}.
 # Empty (default) means "{token_type} {token}"; use "{token}" to send the raw
 # credential without a Bearer prefix (typical for subscription keys).


### PR DESCRIPTION
## Problem

QA alert `ContainerCPUThrottledSustained` on `mcp-granola-server` (~97% of periods) and `mcp-linear-server` (~66%): both pods pinned flat at their 500m CPU limit with near-zero traffic. py-spy on the live pods showed the asyncio MainThread spinning in anyio's `_deliver_cancellation` — identical stack on both — with ~74 CPU-hours burned on the granola pod and 0 remaining remote sockets.

## Root cause

In `RemoteMCPClientStrategy.session()`, teardown after a request cancellation ran:

```python
await asyncio.shield(stack.aclose())
```

`stack` holds `streamablehttp_client`/`sse_client` — **anyio task groups**. An uncancellable `asyncio.shield` future inside an already-cancelled anyio scope makes anyio re-deliver cancellation to the host task on every event-loop tick, forever. Only the `MCP_REMOTE_SERVER` deployments hit this; stdio bridges don't touch the code path.

## Fix

Close under anyio's native shielded scope, bounded by a timeout:

```python
with anyio.move_on_after(MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS, shield=True):
    await stack.aclose()
```

- anyio shield → no cancellation-delivery spin
- `move_on_after` → teardown can never hang the handler for more than `MCP_REMOTE_TEARDOWN_TIMEOUT_SECONDS` (env-configurable, default 10s); a timeout logs a warning and abandons the close
- same bounded path for normal and cancelled exits (previous split no longer needed)

## Verification

- New regression test `test_remote_strategy_teardown_bounded_when_close_hangs`: hanging transport `__aexit__` + mid-session cancel must exit within the timeout. Reproduced the unbounded hang on current main with the same scenario before writing the fix.
- `pytest app/session/`: 19 passed.
- `black --check` clean on all touched files.

## Notes

- mcp SDK stays `>=1.22,<2`; tests pass on 1.29.0/anyio 4.14.2 (deployed pods run 1.28.1/4.14.1 — no SDK change needed, the bug is ours).
- After merge: rebuild image and redeploy `mcp-granola-server` + `mcp-linear-server` (and other `MCP_REMOTE_SERVER` deployments); post-deploy check is `rate(container_cpu_cfs_throttled_periods_total)` ≈ 0 at idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)