### PR TITLE
feat(testing): installable root package with a [testing] extra for black-box conformance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint_and_test:
     name: Lint, Format, and Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,5 +17,26 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile 
-          push: false 
+          file: ./Dockerfile
+          push: false
+
+  package_install_and_conformance:
+    name: Package Install (testing extra) and Bridge Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install root package with the testing extra
+        run: pip install ".[testing]"
+
+      - name: Verify the installed package imports outside the checkout
+        run: cd "$RUNNER_TEMP" && python -c "import enterprise_mcp_bridge.testing, app.server"
+
+      - name: Run canonical bridge conformance tests
+        run: pytest tests/

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -18,6 +18,7 @@
   * [Deploy to Kubernetes](how-to/kubernetes.md)
   * [UI Generation](how-to/ui-generation.md)
   * [Workflows and Agents](how-to/workflows.md)
+  * [Test Your MCP Through the Bridge](how-to/test-through-the-bridge.md)
 
 * **Reference**
   * [API Reference](reference/api.md)

--- a/docs/how-to/test-through-the-bridge.md
+++ b/docs/how-to/test-through-the-bridge.md
@@ -1,0 +1,76 @@
+# Test Your MCP Through the Bridge
+
+Run your MCP repository's tests against the *real* bridge — real FastAPI app,
+real routes, real stdio child process — without Kubernetes or network access.
+The first time your server meets the bridge should be CI, not the production
+deploy.
+
+## Install
+
+```bash
+pip install "enterprise-mcp-bridge[testing] @ git+https://github.com/inxm-ai/enterprise-mcp-bridge@<tag>"
+```
+
+Pin a tag. The `testing` extra adds pytest; the test-support API itself only
+needs the package's runtime dependencies.
+
+## Use
+
+```python
+import sys
+
+import pytest
+
+from enterprise_mcp_bridge.testing import bridge_client
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    with bridge_client(f"{sys.executable} tests/conformance_server.py") as client:
+        yield client
+
+
+def test_my_tool(bridge):
+    response = bridge.post("/tools/search", json={"query": "inxm"})
+    assert response.status_code == 200
+```
+
+`bridge_client(mcp_server_command, env=None)` is the whole API:
+
+| Parameter | Meaning |
+|---|---|
+| `mcp_server_command` | Exactly what production sets as `MCP_SERVER_COMMAND`. Use `sys.executable` and absolute paths. |
+| `env` | Extra environment variables (e.g. `EFFECT_TOOLS`), applied before the app loads and restored afterwards. |
+
+It yields a [`fastapi.testclient.TestClient`](https://fastapi.tiangolo.com/reference/testclient/)
+bound to the same `app.server:app` object production serves. The bridge spawns
+your server as a stdio child per request, or per session via
+`POST /session/start` — identical to production.
+
+## Offline conformance servers
+
+Real tool calls often reach real APIs. Keep the suite offline by exposing a
+second entrypoint that registers the same tools with a scripted worker:
+production uses `mcp/server.py` → `create_server(real_worker)`; tests use
+`tests/conformance_server.py` → `create_server(scripted_worker)`. Point
+`bridge_client` at the conformance entrypoint — same registration code, same
+stdio path, only the infrastructure edge is substituted.
+
+## What you don't need to test
+
+The generic bridge behaviours — startup and tool listing, session isolation,
+the dry-run gate, child tool exception → HTTP status mapping — are proven once
+in this repo (`tests/test_bridge_conformance.py`). Your suite only adds cases
+for your own tools: at least one success case, plus repo-specific failure
+cases where useful.
+
+## Caveats
+
+- The app module is imported once per process, and a few settings
+  (`EFFECT_TOOLS`, OTLP endpoints, `SERVICE_NAME`) are read at import time.
+  The first `bridge_client(...)` in a pytest run fixes those for the whole
+  run; `MCP_SERVER_COMMAND` itself is re-read per request and may differ
+  between contexts.
+- The child process needs its dependencies importable by the interpreter you
+  put in `mcp_server_command` — in CI, install your MCP package into the same
+  environment.

--- a/docs/how-to/test-through-the-bridge.md
+++ b/docs/how-to/test-through-the-bridge.md
@@ -99,3 +99,8 @@ cases where useful.
 - The child process needs its dependencies importable by the interpreter you
   put in `mcp_server_command` — in CI, install your MCP package into the same
   environment.
+- **stdio only.** `bridge_client` exercises the bridge's `MCP_SERVER_COMMAND`
+  child-process path exclusively. The bridge's separate remote-MCP mode
+  (`MCP_REMOTE_SERVER`, see [Use Remote MCP Servers](remote-mcp-servers.md)) is
+  a different client strategy — HTTP + OAuth to a hosted server, no child
+  process — and is not supported by this fixture.

--- a/docs/how-to/test-through-the-bridge.md
+++ b/docs/how-to/test-through-the-bridge.md
@@ -47,6 +47,18 @@ bound to the same `app.server:app` object production serves. The bridge spawns
 your server as a stdio child per request, or per session via
 `POST /session/start` — identical to production.
 
+Session children are yours to end: a session's child process stays alive until
+`POST /session/close` is called with its id — leaving the `bridge_client`
+context does **not** close it. Close every session your test starts:
+
+```python
+session_id = bridge.post("/session/start").json()["x-inxm-mcp-session"]
+try:
+    ...
+finally:
+    bridge.post("/session/close", headers={"x-inxm-mcp-session": session_id})
+```
+
 ## Offline conformance servers
 
 Real tool calls often reach real APIs. Keep the suite offline by exposing a

--- a/docs/how-to/test-through-the-bridge.md
+++ b/docs/how-to/test-through-the-bridge.md
@@ -17,16 +17,21 @@ needs the package's runtime dependencies.
 ## Use
 
 ```python
+import shlex
 import sys
 
 import pytest
 
 from enterprise_mcp_bridge.testing import bridge_client
 
+CONFORMANCE_SERVER_COMMAND = " ".join(
+    shlex.quote(part) for part in (sys.executable, "tests/conformance_server.py")
+)
+
 
 @pytest.fixture(scope="module")
 def bridge():
-    with bridge_client(f"{sys.executable} tests/conformance_server.py") as client:
+    with bridge_client(CONFORMANCE_SERVER_COMMAND) as client:
         yield client
 
 
@@ -39,8 +44,16 @@ def test_my_tool(bridge):
 
 | Parameter | Meaning |
 |---|---|
-| `mcp_server_command` | Exactly what production sets as `MCP_SERVER_COMMAND`. Use `sys.executable` and absolute paths. |
+| `mcp_server_command` | Exactly what production sets as `MCP_SERVER_COMMAND`. Use `sys.executable` and absolute paths. The bridge parses it with `shlex.split()`, so quote each part yourself (`shlex.quote`) — paths with spaces otherwise split incorrectly. Must not be blank; `bridge_client` raises `ValueError` if it is, since a blank value would silently fall back to the bridge's own default demo server. |
 | `env` | Extra environment variables (e.g. `EFFECT_TOOLS`), applied before the app loads and restored afterwards. |
+
+`app` is a common top-level package name, and pytest puts your repository root
+on `sys.path`. `bridge_client` resolves its own `app` package by location, not
+by search order, so it wins the first import even if your repository also has
+a top-level `app` package — but if that package was already imported earlier
+in the same test process, the collision is unresolvable and `bridge_client`
+raises `RuntimeError` rather than guessing. Import `enterprise_mcp_bridge.testing`
+before your own `app` package if you hit this.
 
 It yields a [`fastapi.testclient.TestClient`](https://fastapi.tiangolo.com/reference/testclient/)
 bound to the same `app.server:app` object production serves. The bridge spawns

--- a/enterprise_mcp_bridge/__init__.py
+++ b/enterprise_mcp_bridge/__init__.py
@@ -1,0 +1,7 @@
+"""Consumer-facing package for the enterprise MCP bridge.
+
+The bridge application itself lives in the ``app`` package (``app.server:app``,
+exactly what production serves via uvicorn). This package holds the small,
+intentional surface exposed to other repositories — currently only
+:mod:`enterprise_mcp_bridge.testing`.
+"""

--- a/enterprise_mcp_bridge/testing.py
+++ b/enterprise_mcp_bridge/testing.py
@@ -1,0 +1,78 @@
+"""Test support for repositories that serve their MCP through the bridge.
+
+Install with the ``testing`` extra::
+
+    pip install "enterprise-mcp-bridge[testing] @ git+https://github.com/inxm-ai/enterprise-mcp-bridge@<tag>"
+
+and use the one public entrypoint::
+
+    from enterprise_mcp_bridge.testing import bridge_client
+
+    with bridge_client(f"{sys.executable} tests/conformance_server.py") as client:
+        response = client.get("/tools")
+
+What it does
+------------
+Creates the *real* bridge FastAPI application in-process (the same
+``app.server:app`` object production serves) and yields a
+``fastapi.testclient.TestClient`` against it. There is no test-only app, no
+test-only route, and no faked transport: the bridge resolves
+``MCP_SERVER_COMMAND`` per request/session and spawns the MCP server as a
+stdio child process exactly as it does in production.
+
+Child-process lifecycle
+-----------------------
+The bridge owns the child. Sessionless requests spawn a child for the duration
+of the request; ``POST /session/start`` spawns one that lives until the session
+is closed or the client context exits. Nothing needs Kubernetes or the network
+— everything stays on this machine, offline.
+
+Supported configuration
+-----------------------
+``mcp_server_command``
+    Required. The exact ``MCP_SERVER_COMMAND`` production would use, e.g.
+    ``f"{sys.executable} path/to/server.py"``. Prefer absolute paths and
+    ``sys.executable`` so the test does not depend on the working directory
+    or a ``python`` on PATH.
+``env``
+    Optional extra environment variables (e.g. ``EFFECT_TOOLS``, ``MCP_ENV``).
+    Applied before the app is imported and restored on exit.
+
+Caveat: the bridge reads a few variables at *import* time (``EFFECT_TOOLS``,
+OTLP settings, ``SERVICE_NAME``), and the app module is imported once per
+process. The first ``bridge_client(...)`` in a pytest run therefore fixes those
+values for the whole run; ``MCP_SERVER_COMMAND`` itself is read per request and
+can differ between contexts.
+"""
+
+import os
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+MCP_SERVER_COMMAND_VAR = "MCP_SERVER_COMMAND"
+
+
+@contextmanager
+def bridge_client(
+    mcp_server_command: str,
+    env: Mapping[str, str] | None = None,
+) -> Iterator[TestClient]:
+    """Yield a ``TestClient`` for the real bridge app wired to the given MCP server."""
+    overrides = {MCP_SERVER_COMMAND_VAR: mcp_server_command, **(env or {})}
+    previous = {name: os.environ.get(name) for name in overrides}
+    os.environ.update(overrides)
+    try:
+        # Imported lazily so `overrides` is in place for the bridge's
+        # import-time configuration reads on first use.
+        from app.server import app
+
+        with TestClient(app) as client:
+            yield client
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/enterprise_mcp_bridge/testing.py
+++ b/enterprise_mcp_bridge/testing.py
@@ -21,6 +21,15 @@ test-only route, and no faked transport: the bridge resolves
 ``MCP_SERVER_COMMAND`` per request/session and spawns the MCP server as a
 stdio child process exactly as it does in production.
 
+Scope: stdio only
+-----------------
+This fixture only exercises the bridge's stdio-child code path
+(``MCP_SERVER_COMMAND``). The bridge also has a separate remote-MCP mode
+(``MCP_REMOTE_SERVER``, see ``docs/how-to/remote-mcp-servers.md``) that talks
+to a hosted MCP over HTTP instead of spawning a child — a structurally
+different client strategy, mutually exclusive with ``MCP_SERVER_COMMAND`` in
+the bridge itself. ``bridge_client`` does not cover it.
+
 Child-process lifecycle
 -----------------------
 The bridge owns the child. Sessionless requests spawn a child for the duration
@@ -91,7 +100,9 @@ def bridge_client(
         raise ValueError(
             "mcp_server_command must not be blank: the bridge falls back to its "
             "own default demo server when MCP_SERVER_COMMAND is unset, which "
-            "would silently test the wrong MCP server."
+            "would silently test the wrong MCP server. bridge_client only "
+            "supports stdio-spawned MCP servers; the bridge's remote-MCP mode "
+            "(MCP_REMOTE_SERVER) is not supported by this fixture."
         )
 
     existing_app = sys.modules.get("app")

--- a/enterprise_mcp_bridge/testing.py
+++ b/enterprise_mcp_bridge/testing.py
@@ -8,7 +8,8 @@ and use the one public entrypoint::
 
     from enterprise_mcp_bridge.testing import bridge_client
 
-    with bridge_client(f"{sys.executable} tests/conformance_server.py") as client:
+    command = " ".join(shlex.quote(p) for p in (sys.executable, "tests/conformance_server.py"))
+    with bridge_client(command) as client:
         response = client.get("/tools")
 
 What it does
@@ -32,10 +33,11 @@ Kubernetes or the network — everything stays on this machine, offline.
 Supported configuration
 -----------------------
 ``mcp_server_command``
-    Required. The exact ``MCP_SERVER_COMMAND`` production would use, e.g.
-    ``f"{sys.executable} path/to/server.py"``. Prefer absolute paths and
-    ``sys.executable`` so the test does not depend on the working directory
-    or a ``python`` on PATH.
+    Required. The exact ``MCP_SERVER_COMMAND`` production would use. The
+    bridge parses it with ``shlex.split()``, so quote each part yourself
+    (``shlex.quote``) — ``sys.executable`` and repository paths can contain
+    spaces. Prefer absolute paths and ``sys.executable`` so the test does not
+    depend on the working directory or a ``python`` on PATH.
 ``env``
     Optional extra environment variables (e.g. ``EFFECT_TOOLS``, ``MCP_ENV``).
     Applied before the app is imported and restored on exit.
@@ -45,15 +47,38 @@ OTLP settings, ``SERVICE_NAME``), and the app module is imported once per
 process. The first ``bridge_client(...)`` in a pytest run therefore fixes those
 values for the whole run; ``MCP_SERVER_COMMAND`` itself is read per request and
 can differ between contexts.
+
+Caveat: ``app`` is a common top-level package name, and pytest puts a
+consumer's own repository root on ``sys.path``. ``bridge_client`` resolves its
+own ``app`` package by location (a sibling of this module, not by search
+order) and inserts it first, so the bridge's app wins the first import in the
+process. If a *different* ``app`` package was already imported earlier in the
+same process, that is an unresolvable naming collision and ``bridge_client``
+raises ``RuntimeError`` rather than silently picking one.
 """
 
 import os
+import sys
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 MCP_SERVER_COMMAND_VAR = "MCP_SERVER_COMMAND"
+# Sibling of this package in both an installed layout (pyproject.toml packages
+# `app*` and `enterprise_mcp_bridge*` as top-level siblings) and a checkout of
+# this repo. Resolving the bridge's own `app` package from here — rather than
+# relying on sys.path search order — is what keeps `from app.server import
+# app` from picking up a consumer repository's own top-level `app` package.
+_BRIDGE_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _is_bridges_own_app_module(module) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return False
+    return Path(module_file).resolve().is_relative_to(_BRIDGE_ROOT)
 
 
 @contextmanager
@@ -62,17 +87,41 @@ def bridge_client(
     env: Mapping[str, str] | None = None,
 ) -> Iterator[TestClient]:
     """Yield a ``TestClient`` for the real bridge app wired to the given MCP server."""
+    if not mcp_server_command or not mcp_server_command.strip():
+        raise ValueError(
+            "mcp_server_command must not be blank: the bridge falls back to its "
+            "own default demo server when MCP_SERVER_COMMAND is unset, which "
+            "would silently test the wrong MCP server."
+        )
+
+    existing_app = sys.modules.get("app")
+    if existing_app is not None and not _is_bridges_own_app_module(existing_app):
+        raise RuntimeError(
+            "A module named `app` is already imported and is not the bridge's "
+            f"own `app` package (expected under {_BRIDGE_ROOT}). This usually "
+            "means the consumer repository also has a top-level `app` package "
+            "that pytest imported first; import `enterprise_mcp_bridge.testing` "
+            "before your own `app` package, or rename one of the two."
+        )
+
     overrides = {MCP_SERVER_COMMAND_VAR: mcp_server_command, **(env or {})}
     previous = {name: os.environ.get(name) for name in overrides}
     os.environ.update(overrides)
+    bridge_root_str = str(_BRIDGE_ROOT)
+    path_inserted = bridge_root_str not in sys.path
+    if path_inserted:
+        sys.path.insert(0, bridge_root_str)
     try:
-        # Imported lazily so `overrides` is in place for the bridge's
-        # import-time configuration reads on first use.
+        # Imported lazily so `overrides` and the sys.path insertion above are
+        # in place for the bridge's import-time configuration reads and for
+        # resolving `app` to the bridge's own package on first use.
         from app.server import app
 
         with TestClient(app) as client:
             yield client
     finally:
+        if path_inserted:
+            sys.path.remove(bridge_root_str)
         for name, value in previous.items():
             if value is None:
                 os.environ.pop(name, None)

--- a/enterprise_mcp_bridge/testing.py
+++ b/enterprise_mcp_bridge/testing.py
@@ -23,9 +23,11 @@ stdio child process exactly as it does in production.
 Child-process lifecycle
 -----------------------
 The bridge owns the child. Sessionless requests spawn a child for the duration
-of the request; ``POST /session/start`` spawns one that lives until the session
-is closed or the client context exits. Nothing needs Kubernetes or the network
-— everything stays on this machine, offline.
+of the request. ``POST /session/start`` spawns a child that lives until you
+call ``POST /session/close`` with the session id — exiting the
+``bridge_client`` context does NOT close open sessions, so close every session
+your test starts (a ``finally`` block or fixture teardown). Nothing needs
+Kubernetes or the network — everything stays on this machine, offline.
 
 Supported configuration
 -----------------------

--- a/enterprise_mcp_bridge/testing.py
+++ b/enterprise_mcp_bridge/testing.py
@@ -108,11 +108,15 @@ def bridge_client(
     previous = {name: os.environ.get(name) for name in overrides}
     os.environ.update(overrides)
     bridge_root_str = str(_BRIDGE_ROOT)
-    path_inserted = bridge_root_str not in sys.path
-    if path_inserted:
-        sys.path.insert(0, bridge_root_str)
+    original_sys_path = sys.path.copy()
+    # Always move the bridge's own package ahead of the rest of sys.path, even
+    # when it is already present (e.g. via site-packages): a consumer
+    # repository root sits ahead of site-packages once pytest inserts it, so
+    # leaving the existing position in place would still let the consumer's
+    # own top-level `app` package win the import below.
+    sys.path[:] = [bridge_root_str] + [p for p in sys.path if p != bridge_root_str]
     try:
-        # Imported lazily so `overrides` and the sys.path insertion above are
+        # Imported lazily so `overrides` and the sys.path reordering above are
         # in place for the bridge's import-time configuration reads and for
         # resolving `app` to the bridge's own package on first use.
         from app.server import app
@@ -120,8 +124,7 @@ def bridge_client(
         with TestClient(app) as client:
             yield client
     finally:
-        if path_inserted:
-            sys.path.remove(bridge_root_str)
+        sys.path[:] = original_sys_path
         for name, value in previous.items():
             if value is None:
                 os.environ.pop(name, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+# Root packaging for consumers: `pip install "enterprise-mcp-bridge[testing] @ git+...@<tag>"`.
+# The Docker image keeps installing from app/pyproject.toml — keep the two dependency
+# lists and versions in sync when either changes.
+[project]
+name = "enterprise-mcp-bridge"
+version = "0.4.10"
+description = "Wrapper for MCP Clients to be called via REST on a platform"
+license = "GPL-3.0"
+authors = [{ name = "Matthias Kainer", email = "matthias@inxm.ai" }]
+requires-python = ">=3.11"
+dependencies = [
+    "httpx",
+    "fastapi",
+    "uvicorn",
+    "mcp[cli]>=1.22,<2",
+    "celery",
+    "PyJWT",
+    "requests",
+    "aiohttp",
+    "prometheus-fastapi-instrumentator>=8,<9",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-instrumentation-fastapi",
+    "openai",
+    "genson",
+    "psycopg[binary]"
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.optional-dependencies]
+testing = [
+    "pytest",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["app*", "enterprise_mcp_bridge*"]
+
+# Non-Python files app_facade loads at import time; without these the
+# installed package cannot even import app.server.
+[tool.setuptools.package-data]
+"app.app_facade" = ["*.md", "templates/*"]

--- a/tests/oauth_env_probe_server.py
+++ b/tests/oauth_env_probe_server.py
@@ -1,0 +1,23 @@
+"""Test-only probe server for the bridge's own conformance suite.
+
+Exists solely to prove that OAUTH_ENV token propagation actually reaches the
+child process (see test_bridge_conformance.py). Kept separate from
+mcp/server.py — the real default fallback MCP server — so that production
+default does not gain an env-var-echoing tool.
+"""
+
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("mcp-oauth-env-probe-server")
+
+
+@mcp.tool()
+def read_env(name: str) -> str:
+    """Return the value of an environment variable in this process, or "" if unset."""
+    return os.environ.get(name, "")
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -45,7 +45,18 @@ HTTP_TOOL_EXECUTION_ERROR = 422
 @pytest.fixture(scope="module")
 def bridge():
     with bridge_client(
-        DEMO_SERVER_COMMAND, env={"EFFECT_TOOLS": EFFECT_TOOLS_CONFIG}
+        DEMO_SERVER_COMMAND,
+        env={
+            "EFFECT_TOOLS": EFFECT_TOOLS_CONFIG,
+            # Pinned so test_oauth_env_propagates_the_caller_access_token_into_the_child
+            # owns the pass-through condition it claims to prove, rather than
+            # inheriting whatever AUTH_PROVIDER/KEYCLOAK_PROVIDER_ALIAS happen to
+            # be set in the developer's or CI's ambient environment. These match
+            # app/vars.py's own defaults, so this only makes the dependency
+            # explicit — it does not change default behavior.
+            "AUTH_PROVIDER": "keycloak",
+            "KEYCLOAK_PROVIDER_ALIAS": "",
+        },
     ) as client:
         yield client
         client.cookies.clear()
@@ -166,13 +177,14 @@ def test_oauth_env_propagates_the_caller_access_token_into_the_child(
 ):
     """OAUTH_ENV is the bridge's real (unmocked) token-propagation seam.
 
-    With the default AUTH_PROVIDER=keycloak and no KEYCLOAK_PROVIDER_ALIAS
-    configured, KeyCloakTokenRetriever passes the caller's access token
-    through unchanged (app/oauth/token_exchange.py), with no network call —
-    so this needs no mocking, only a child that can read its own environment
-    back (tests/oauth_env_probe_server.py). MCP_SERVER_COMMAND is swapped for
-    just this one request; child spawn is per-request, so the other tests in
-    this module are unaffected.
+    With AUTH_PROVIDER=keycloak and no KEYCLOAK_PROVIDER_ALIAS — pinned in the
+    `bridge` fixture's env, not left to whatever the developer's or CI's
+    ambient environment happens to have — KeyCloakTokenRetriever passes the
+    caller's access token through unchanged (app/oauth/token_exchange.py),
+    with no network call. So this needs no mocking, only a child that can
+    read its own environment back (tests/oauth_env_probe_server.py).
+    MCP_SERVER_COMMAND is swapped for just this one request; child spawn is
+    per-request, so the other tests in this module are unaffected.
     """
     monkeypatch.setenv("MCP_SERVER_COMMAND", OAUTH_ENV_PROBE_COMMAND)
     monkeypatch.setenv("OAUTH_ENV", "PROPAGATED_TOKEN")

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -9,6 +9,7 @@ Runs offline with plain pytest — no Kubernetes, no network.
 """
 
 import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -154,3 +155,42 @@ def test_dry_run_never_executes_the_effect_tool(bridge):
         assert _call_counter(bridge, session_id) == 2
     finally:
         _close_session(bridge, session_id)
+
+
+def test_bridge_own_app_wins_over_a_consumer_top_level_app_package(tmp_path):
+    """Regression: a consumer's own `app` package must not shadow the bridge's.
+
+    Must run in a fresh interpreter: this file's own `bridge` fixture already
+    imports the real `app.server` earlier in-process, so by the time any other
+    test here runs, `sys.modules["app"]` is already the bridge's own module
+    and the collision this guards against can no longer be observed.
+
+    A consumer's top-level `app` package lives in their repository root, which
+    pytest puts ahead of site-packages on `sys.path`. Reproduced here by
+    running the subprocess with `cwd=tmp_path`: for `python -c`, `sys.path[0]`
+    is `''` (cwd), so a fake `app` package placed there sits ahead of the
+    installed bridge package exactly as a consumer repo root would.
+    """
+    fake_app = tmp_path / "app"
+    fake_app.mkdir()
+    (fake_app / "__init__.py").write_text("")
+    (fake_app / "server.py").write_text("app = 'THIS-IS-THE-CONSUMERS-OWN-APP'\n")
+
+    script = f"""
+import sys
+from enterprise_mcp_bridge.testing import bridge_client
+
+with bridge_client({DEMO_SERVER_COMMAND!r}) as client:
+    response = client.get("/tools")
+    assert response.status_code == 200, response.text
+    tool_names = {{tool["name"] for tool in response.json()}}
+    assert "add" in tool_names, f"got the consumer's app instead of the bridge's: {{tool_names}}"
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -24,6 +24,11 @@ EFFECT_TOOLS_CONFIG = "call_counter"
 
 HTTP_OK = 200
 HTTP_INTERNAL_ERROR = 500
+# The externally intended contract: a tool that ran and rejected the request is
+# a client-side failure, never a bridge fault. Asserted as a literal on purpose
+# — importing the bridge's own constant would keep this test green if the
+# constant and the behavior drifted together.
+HTTP_TOOL_EXECUTION_ERROR = 422
 
 
 @pytest.fixture(scope="module")
@@ -61,6 +66,13 @@ def _start_session(bridge) -> str:
     return response.json()[SESSION_HEADER]
 
 
+def _close_session(bridge, session_id: str) -> None:
+    # Sessions hold a live child process until closed; cookie clearing alone
+    # only detaches the client, it does not end the session.
+    response = bridge.post("/session/close", headers={SESSION_HEADER: session_id})
+    assert response.status_code == HTTP_OK, response.text
+
+
 def _call_counter(bridge, session_id: str, headers: dict | None = None) -> object:
     response = bridge.post(
         "/tools/call_counter",
@@ -85,23 +97,28 @@ def test_tool_invocation_returns_structured_result(bridge):
 
 
 def test_sessions_are_isolated_from_each_other(bridge):
-    first_session = _start_session(bridge)
-    bridge.cookies.clear()
-    second_session = _start_session(bridge)
-    bridge.cookies.clear()
+    sessions = []
+    try:
+        first_session = _start_session(bridge)
+        sessions.append(first_session)
+        bridge.cookies.clear()
+        second_session = _start_session(bridge)
+        sessions.append(second_session)
+        bridge.cookies.clear()
 
-    assert first_session != second_session
-    assert _call_counter(bridge, first_session) == 1
-    assert _call_counter(bridge, first_session) == 2
-    # The second session has its own child process, so its counter is fresh.
-    assert _call_counter(bridge, second_session) == 1
+        assert first_session != second_session
+        assert _call_counter(bridge, first_session) == 1
+        assert _call_counter(bridge, first_session) == 2
+        # The second session has its own child process, so its counter is fresh.
+        assert _call_counter(bridge, second_session) == 1
+    finally:
+        for session_id in sessions:
+            _close_session(bridge, session_id)
 
 
 def test_child_tool_exception_maps_to_tool_execution_error(bridge):
-    from app.routes import HTTP_STATUS_TOOL_EXECUTION_ERROR
-
     response = bridge.post("/tools/error", json={"message": "boom"})
-    assert response.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR, response.text
+    assert response.status_code == HTTP_TOOL_EXECUTION_ERROR, response.text
 
 
 def test_dry_run_header_is_inert_for_non_effect_tools(bridge):
@@ -116,16 +133,18 @@ def test_dry_run_header_is_inert_for_non_effect_tools(bridge):
 def test_dry_run_never_executes_the_effect_tool(bridge):
     _require_effect_tools_gate()
     session_id = _start_session(bridge)
+    try:
+        assert _call_counter(bridge, session_id) == 1
 
-    assert _call_counter(bridge, session_id) == 1
+        # Offline there is no TGI_URL, so the dry-run path fails server-side —
+        # what matters here is that the real tool is never reached.
+        dry_run = bridge.post(
+            "/tools/call_counter",
+            headers={SESSION_HEADER: session_id, "X-Inxm-Dry-Run": "true"},
+            json={},
+        )
+        assert dry_run.status_code == HTTP_INTERNAL_ERROR, dry_run.text
 
-    # Offline there is no TGI_URL, so the dry-run path fails server-side —
-    # what matters here is that the real tool is never reached.
-    dry_run = bridge.post(
-        "/tools/call_counter",
-        headers={SESSION_HEADER: session_id, "X-Inxm-Dry-Run": "true"},
-        json={},
-    )
-    assert dry_run.status_code == HTTP_INTERNAL_ERROR, dry_run.text
-
-    assert _call_counter(bridge, session_id) == 2
+        assert _call_counter(bridge, session_id) == 2
+    finally:
+        _close_session(bridge, session_id)

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -8,6 +8,7 @@ bridge repo; MCP repositories only add their own tool-specific cases on top.
 Runs offline with plain pytest — no Kubernetes, no network.
 """
 
+import shlex
 import sys
 from pathlib import Path
 
@@ -16,7 +17,12 @@ import pytest
 from enterprise_mcp_bridge.testing import bridge_client
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEMO_SERVER_COMMAND = f"{sys.executable} {REPO_ROOT / 'mcp' / 'server.py'}"
+# get_server_params() parses MCP_SERVER_COMMAND with shlex.split(), so both
+# parts must be individually quoted — sys.executable and the repo checkout
+# path can each contain spaces (e.g. under "Application Support" on macOS).
+DEMO_SERVER_COMMAND = " ".join(
+    shlex.quote(part) for part in (sys.executable, str(REPO_ROOT / "mcp" / "server.py"))
+)
 SESSION_HEADER = "x-inxm-mcp-session"
 # call_counter both proves session isolation (stateful child) and, marked as an
 # effect tool, proves dry-run never reaches the real tool.

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -1,0 +1,131 @@
+"""Canonical black-box conformance suite for the bridge itself.
+
+Uses only the public test-support API (``enterprise_mcp_bridge.testing``)
+against the repo's demo MCP server (``mcp/server.py``), spawned over the real
+stdio child boundary. This proves the generic bridge behaviours once, in the
+bridge repo; MCP repositories only add their own tool-specific cases on top.
+
+Runs offline with plain pytest — no Kubernetes, no network.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from enterprise_mcp_bridge.testing import bridge_client
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEMO_SERVER_COMMAND = f"{sys.executable} {REPO_ROOT / 'mcp' / 'server.py'}"
+SESSION_HEADER = "x-inxm-mcp-session"
+# call_counter both proves session isolation (stateful child) and, marked as an
+# effect tool, proves dry-run never reaches the real tool.
+EFFECT_TOOLS_CONFIG = "call_counter"
+
+HTTP_OK = 200
+HTTP_INTERNAL_ERROR = 500
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    with bridge_client(
+        DEMO_SERVER_COMMAND, env={"EFFECT_TOOLS": EFFECT_TOOLS_CONFIG}
+    ) as client:
+        yield client
+        client.cookies.clear()
+
+
+@pytest.fixture(autouse=True)
+def _sessionless_by_default(bridge):
+    # /session/start sets a session cookie on the shared client; clear it so
+    # every test starts sessionless unless it opts in explicitly.
+    bridge.cookies.clear()
+
+
+def _require_effect_tools_gate():
+    # EFFECT_TOOLS is read when the app module is first imported. If another
+    # test file imported it earlier without the gate configured (full-suite
+    # runs from the repo root), the dry-run cases cannot be proven here.
+    from app.vars import EFFECT_TOOLS
+
+    if EFFECT_TOOLS_CONFIG not in EFFECT_TOOLS:
+        pytest.skip(
+            "app was imported before EFFECT_TOOLS could be set; "
+            "run `pytest tests/` in its own process for the dry-run cases"
+        )
+
+
+def _start_session(bridge) -> str:
+    response = bridge.post("/session/start")
+    assert response.status_code == HTTP_OK, response.text
+    return response.json()[SESSION_HEADER]
+
+
+def _call_counter(bridge, session_id: str, headers: dict | None = None) -> object:
+    response = bridge.post(
+        "/tools/call_counter",
+        headers={SESSION_HEADER: session_id, **(headers or {})},
+        json={},
+    )
+    assert response.status_code == HTTP_OK, response.text
+    return response.json()["structuredContent"]["result"]
+
+
+def test_startup_lists_the_child_tools(bridge):
+    response = bridge.get("/tools")
+    assert response.status_code == HTTP_OK, response.text
+    tool_names = [tool["name"] for tool in response.json()]
+    assert {"add", "hello", "error", "call_counter"} <= set(tool_names)
+
+
+def test_tool_invocation_returns_structured_result(bridge):
+    response = bridge.post("/tools/add", json={"a": 2, "b": 3})
+    assert response.status_code == HTTP_OK, response.text
+    assert response.json()["structuredContent"]["result"] == 5
+
+
+def test_sessions_are_isolated_from_each_other(bridge):
+    first_session = _start_session(bridge)
+    bridge.cookies.clear()
+    second_session = _start_session(bridge)
+    bridge.cookies.clear()
+
+    assert first_session != second_session
+    assert _call_counter(bridge, first_session) == 1
+    assert _call_counter(bridge, first_session) == 2
+    # The second session has its own child process, so its counter is fresh.
+    assert _call_counter(bridge, second_session) == 1
+
+
+def test_child_tool_exception_maps_to_tool_execution_error(bridge):
+    from app.routes import HTTP_STATUS_TOOL_EXECUTION_ERROR
+
+    response = bridge.post("/tools/error", json={"message": "boom"})
+    assert response.status_code == HTTP_STATUS_TOOL_EXECUTION_ERROR, response.text
+
+
+def test_dry_run_header_is_inert_for_non_effect_tools(bridge):
+    _require_effect_tools_gate()
+    response = bridge.post(
+        "/tools/add", headers={"X-Inxm-Dry-Run": "true"}, json={"a": 2, "b": 3}
+    )
+    assert response.status_code == HTTP_OK, response.text
+    assert response.json()["structuredContent"]["result"] == 5
+
+
+def test_dry_run_never_executes_the_effect_tool(bridge):
+    _require_effect_tools_gate()
+    session_id = _start_session(bridge)
+
+    assert _call_counter(bridge, session_id) == 1
+
+    # Offline there is no TGI_URL, so the dry-run path fails server-side —
+    # what matters here is that the real tool is never reached.
+    dry_run = bridge.post(
+        "/tools/call_counter",
+        headers={SESSION_HEADER: session_id, "X-Inxm-Dry-Run": "true"},
+        json={},
+    )
+    assert dry_run.status_code == HTTP_INTERNAL_ERROR, dry_run.text
+
+    assert _call_counter(bridge, session_id) == 2

--- a/tests/test_bridge_conformance.py
+++ b/tests/test_bridge_conformance.py
@@ -24,6 +24,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEMO_SERVER_COMMAND = " ".join(
     shlex.quote(part) for part in (sys.executable, str(REPO_ROOT / "mcp" / "server.py"))
 )
+OAUTH_ENV_PROBE_COMMAND = " ".join(
+    shlex.quote(part)
+    for part in (sys.executable, str(REPO_ROOT / "tests" / "oauth_env_probe_server.py"))
+)
 SESSION_HEADER = "x-inxm-mcp-session"
 # call_counter both proves session isolation (stateful child) and, marked as an
 # effect tool, proves dry-run never reaches the real tool.
@@ -155,6 +159,33 @@ def test_dry_run_never_executes_the_effect_tool(bridge):
         assert _call_counter(bridge, session_id) == 2
     finally:
         _close_session(bridge, session_id)
+
+
+def test_oauth_env_propagates_the_caller_access_token_into_the_child(
+    bridge, monkeypatch
+):
+    """OAUTH_ENV is the bridge's real (unmocked) token-propagation seam.
+
+    With the default AUTH_PROVIDER=keycloak and no KEYCLOAK_PROVIDER_ALIAS
+    configured, KeyCloakTokenRetriever passes the caller's access token
+    through unchanged (app/oauth/token_exchange.py), with no network call —
+    so this needs no mocking, only a child that can read its own environment
+    back (tests/oauth_env_probe_server.py). MCP_SERVER_COMMAND is swapped for
+    just this one request; child spawn is per-request, so the other tests in
+    this module are unaffected.
+    """
+    monkeypatch.setenv("MCP_SERVER_COMMAND", OAUTH_ENV_PROBE_COMMAND)
+    monkeypatch.setenv("OAUTH_ENV", "PROPAGATED_TOKEN")
+    access_token = "conformance-test-token-123"  # noqa: S105 -- not a real credential
+
+    response = bridge.post(
+        "/tools/read_env",
+        headers={"X-Auth-Request-Access-Token": access_token},
+        json={"name": "PROPAGATED_TOKEN"},
+    )
+
+    assert response.status_code == HTTP_OK, response.text
+    assert response.json()["structuredContent"]["result"] == access_token
 
 
 def test_bridge_own_app_wins_over_a_consumer_top_level_app_package(tmp_path):


### PR DESCRIPTION
## Why

Today the first time an MCP server meets the bridge is the production deploy. The deterministic-harness plan ("Black-box conformance via the bridge") moves that meeting into CI: each MCP repo runs its tests against the **real** bridge — real FastAPI app, real routes, real stdio child process — offline, with plain pytest. Prerequisite: the bridge must be installable and expose a small, stable test-support API. `app/pyproject.toml` can't serve that role — it packages only `session`, `session_manager`, `oauth`, `mcp_server` (no `app`, no routes), so installing it doesn't give you the application at all.

## What

- **Root `pyproject.toml`** — installs `app.*` plus a new `enterprise_mcp_bridge` package; `[testing]` extra. Consumer install: `pip install "enterprise-mcp-bridge[testing] @ git+https://github.com/inxm-ai/enterprise-mcp-bridge@<tag>"`. Includes the `app_facade` template files as package-data — the installation test caught that without them the installed package cannot even import `app.server` (prod never noticed because the Docker image imports from the source tree).
- **`enterprise_mcp_bridge.testing.bridge_client(mcp_server_command, env=None)`** — the whole test-support API: one context manager that sets `MCP_SERVER_COMMAND`, imports the same `app.server:app` production serves, and yields a `TestClient`. No app factory was needed: the bridge resolves `MCP_SERVER_COMMAND` per request/session (`server_params.py`), so the module-level app is already the right seam. No test-only endpoints, no production conditionals, no classes.
- **`tests/test_bridge_conformance.py`** — canonical proof of the generic behaviours, once, via the public API against `mcp/server.py` over the real stdio boundary: startup/tool listing, tool invocation, session isolation (`call_counter`), child tool exception → 422 (`HTTP_STATUS_TOOL_EXECUTION_ERROR`), and the offline-provable dry-run behaviour (header inert for non-effect tools; for effect tools the real tool is never executed).
- **CI** — new `package_install_and_conformance` job: `pip install ".[testing]"`, an import check from outside the checkout (the focused installation test), then the conformance suite. The Docker job is untouched.
- **Docs** — how-to page (import path, lifecycle, configuration, caveats) + sidebar entry.

## Deliberately not done

- Docker/Helm, `app/pyproject.toml`, auth policy, error semantics: unchanged. Production behaviour and public routes are identical.
- No app-factory refactor — would touch the prod entrypoint for no behavioural gain.
- MCP-side pieces (`tests/conformance_server.py` in the reference repo, generic case runner) come in the next slice.

## Notes for review

- `EFFECT_TOOLS` is read at app-module import; the dry-run tests skip with an explicit reason if another test file imported the app first (mixed full-suite runs). The CI job runs `pytest tests/` in its own process, where they always execute.
- Root `pyproject.toml` duplicates the dependency list of `app/pyproject.toml` (Docker still installs from `app/`); a header comment marks the sync obligation. Unifying the two is a follow-up, not this PR.

## Verification

- `pip install ".[testing]"` into a fresh venv, import check from a clean cwd: OK (after the package-data fix).
- `pytest tests/` → 6 passed.
- `pytest app/test_app.py app/test_routes_tool_error_status.py app/test_fastapi_with_testclient.py` from repo root (new root pyproject present) → 54 passed.
- Mixed run `pytest app/test_app.py tests/` → 27 passed, 2 skipped (the documented dry-run skip guard).
- `black --check` on the new files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)