### PR TITLE
fix(ci): publish a sha-<shortsha> GHCR tag for lz-aws's by-SHA sync workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -47,6 +47,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && matrix.python-version == env.DEFAULT_PYTHON_VERSION }} # Tag 'latest' only for the default Python version on main
             type=raw,value=latest-${{ matrix.python-version }},enable=${{ github.ref == 'refs/heads/main' }} # Tag latest per Python version on main
             type=ref,event=tag,suffix=-${{ matrix.python-version }} # Tag with the Git tag and Python version if a tag is pushed
+            type=sha,prefix=sha-,format=short,enable=${{ github.ref == 'refs/heads/main' && matrix.python-version == env.DEFAULT_PYTHON_VERSION }} # Tag with the commit SHA (default Python version only) so lz-aws's by-SHA sync workflow has an image to pull for untagged main commits
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Why

`lz-aws`'s [002-2-sync-enterprise-mcp-bridge.yml](https://github.com/inxm-ai/lz-aws/blob/main/.github/workflows/002-2-sync-enterprise-mcp-bridge.yml) takes a `version` input documented as `"e.g., v1.0.0, or sha-6b04b22"` — implying every commit on `main` gets a pullable `sha-<shortsha>` GHCR tag. It doesn't. `grep -rn "sha" .github/workflows/*.yml` in this repo returns nothing: the `docker/metadata-action` tag list here has only ever produced `latest` / `latest-<pyver>` on a push to `main`, and `<git-tag>-<pyver>` on a tag push. Running the lz-aws workflow with `version: sha-<anything>` today fails at `docker pull` — 404, that tag was never published.

## What

One added tag rule, gated identically to the existing `latest` rule (default Python version only, `main` only):

```diff
+            type=sha,prefix=sha-,format=short,enable=${{ github.ref == 'refs/heads/main' && matrix.python-version == env.DEFAULT_PYTHON_VERSION }}
```

Every push to `main` now also publishes `sha-<7-char-shortsha>` to GHCR, matching the exact format lz-aws's own input hint already describes.

## Does this affect the release process?

No. `release.sh` commits a version bump, tags `vX.Y.Z`, and pushes both the branch and the tag. Both pushes already trigger this workflow today; this change adds one more tag to the *same* build the branch push already produces — it doesn't touch `release.sh`, the tag-triggered `release` job (which creates the GitHub Release page), or the `<tag>-<pyver>` tagging scheme at all. Purely additive.

## Note

This only takes effect for commits pushed to `main` *after* this merges — it doesn't retroactively tag already-existing commits (including the just-merged `enterprise-mcp-bridge[testing]` PR, which needs no image change anyway, since it touched neither `app/`, `mcp/`, nor the `Dockerfile`).

## Verification

- YAML parses (`yaml.safe_load`) and the new tag line matches the exact `type=X,attr=...,enable=...` grammar the three existing, CI-proven tag lines already use.
- Confirmed via `grep -rn "sha" .github/workflows/*.yml` (before this change) that no workflow in this repo has ever produced a sha-based tag.
- Actually exercising the new tag requires a real push to `main` and a live GHCR push (the existing CI step's job) — not reproducible locally; flagging this as the one residual risk rather than claiming an end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)