### PR TITLE
feat(telemetry): canonical wide MCP operation spans with fail-closed tool policy (ops-observe#84 Slice 1)

### DIFF
--- a/app/oauth/token_exchange.py
+++ b/app/oauth/token_exchange.py
@@ -66,8 +66,7 @@ def _get_jwks_client():
         import ssl
 
         jwks_url = (
-            f"{AUTH_BASE_URL}/realms/{KEYCLOAK_REALM}"
-            "/protocol/openid-connect/certs"
+            f"{AUTH_BASE_URL}/realms/{KEYCLOAK_REALM}" "/protocol/openid-connect/certs"
         )
         ssl_context = None
         if AUTH_ALLOW_UNSAFE_CERT:
@@ -80,15 +79,20 @@ def _get_jwks_client():
     return _jwks_client
 
 
-def verified_keycloak_claims(token: str) -> Dict[str, Any]:
-    """Verify a Keycloak token before it may release a stored credential.
+def verified_caller_claims(
+    token: str, *, allowed_clients: list, allowlist_name: str
+) -> Dict[str, Any]:
+    """Verify a Keycloak token and return its claims, or fail closed.
 
     Enforces: signature against the realm JWKS, a present and valid exp,
     the exact configured issuer (KEYCLOAK_ISSUER, defaulting to
-    {AUTH_BASE_URL}/realms/{realm}), and that the token was issued to an
-    allow-listed client (azp, falling back to aud). Fails closed with
-    UserLoggedOutException on any violation — including an unconfigured
-    allowlist, so no client in the realm is trusted implicitly.
+    {AUTH_BASE_URL}/realms/{realm}), and that the token was issued to a
+    client in the caller-supplied allowlist (azp, falling back to aud).
+    Fails closed with UserLoggedOutException on any violation — including
+    an empty allowlist, so no client in the realm is trusted implicitly.
+    The bridge accepts direct Bearer tokens (desktop clients bypass the
+    ingress proxy), so any authorization decision based on token claims
+    must go through this function, never an unverified decode.
     """
     try:
         signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
@@ -109,20 +113,29 @@ def verified_keycloak_claims(token: str) -> Dict[str, Any]:
             f"Access token issued by unexpected issuer: {claims.get('iss')}"
         )
 
-    if not USER_API_KEY_ALLOWED_CLIENTS:
+    if not allowed_clients:
         raise UserLoggedOutException(
-            "USER_API_KEY_ALLOWED_CLIENTS is not configured; refusing to "
-            "release credentials for tokens from unspecified clients"
+            f"{allowlist_name} is not configured; refusing to trust tokens "
+            "from unspecified clients"
         )
     azp = claims.get("azp")
     aud = claims.get("aud")
     audiences = aud if isinstance(aud, list) else [aud] if aud else []
     token_clients = [c for c in [azp, *audiences] if c]
-    if not any(c in USER_API_KEY_ALLOWED_CLIENTS for c in token_clients):
+    if not any(c in allowed_clients for c in token_clients):
         raise UserLoggedOutException(
             f"Access token client(s) {token_clients} not in the allowlist"
         )
     return claims
+
+
+def verified_keycloak_claims(token: str) -> Dict[str, Any]:
+    """Verify a Keycloak token before it may release a stored credential."""
+    return verified_caller_claims(
+        token,
+        allowed_clients=USER_API_KEY_ALLOWED_CLIENTS,
+        allowlist_name="USER_API_KEY_ALLOWED_CLIENTS",
+    )
 
 
 class UserApiKeyTokenRetriever(TokenRetriever):
@@ -152,9 +165,7 @@ class UserApiKeyTokenRetriever(TokenRetriever):
         # itself re-validates the token server-side.
         claims = self._verified_claims(keycloak_token)
         email = (
-            claims.get("email")
-            or claims.get("preferred_username")
-            or claims.get("upn")
+            claims.get("email") or claims.get("preferred_username") or claims.get("upn")
         )
         if not email:
             raise UserLoggedOutException(

--- a/app/oauth/user_info.py
+++ b/app/oauth/user_info.py
@@ -283,3 +283,60 @@ class DataAccessManager:
 def get_data_access_manager() -> DataAccessManager:
     """Factory function to get DataAccessManager instance"""
     return DataAccessManager()
+
+
+class CallerNotAuthorizedError(Exception):
+    """The caller may not use this bridge instance (BRIDGE_REQUIRED_GROUPS).
+
+    Carries the HTTP status so transports map it without re-deriving the
+    reason: 401 when identity is missing/unreadable, 403 when the identity is
+    valid but outside the required groups.
+    """
+
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)
+
+
+def ensure_caller_in_required_groups(access_token: Optional[str]) -> None:
+    """Fail closed unless the caller's VERIFIED token carries a required group.
+
+    No-op when BRIDGE_REQUIRED_GROUPS is unset. This gate is an authorization
+    boundary, and the bridge deliberately accepts direct Bearer tokens
+    (desktop clients bypass the ingress proxy) — so group membership is read
+    only from claims that passed signature (realm JWKS), expiry, exact-issuer
+    and client-allowlist (BRIDGE_ALLOWED_CLIENTS) verification. A forged but
+    syntactically valid JWT never reaches the group check.
+    """
+    from app import vars as app_vars
+    from app.oauth.token_exchange import (
+        UserLoggedOutException,
+        verified_caller_claims,
+    )
+
+    required = app_vars.BRIDGE_REQUIRED_GROUPS
+    if not required:
+        return
+    if not access_token:
+        raise CallerNotAuthorizedError(401, "Authentication required")
+    try:
+        claims = verified_caller_claims(
+            access_token,
+            allowed_clients=app_vars.BRIDGE_ALLOWED_CLIENTS,
+            allowlist_name="BRIDGE_ALLOWED_CLIENTS",
+        )
+    except UserLoggedOutException:
+        raise CallerNotAuthorizedError(401, "Access token failed verification")
+    data_manager = get_data_access_manager()
+    extractor = data_manager.user_extractor
+    user_info = {
+        "groups": extractor._extract_groups(claims),
+        "roles": extractor._extract_roles(claims),
+    }
+    if not any(data_manager._user_in_group(user_info, group) for group in required):
+        logger.warning(
+            "[BridgeAuthz] Caller %s denied: not in required groups",
+            claims.get("sub", "<unknown>"),
+        )
+        raise CallerNotAuthorizedError(403, "Not authorized for this bridge")

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enterprise-mcp-bridge"
-version = "0.4.10"
+version = "0.4.11"
 description = "Wrapper for MCP Clients to be called via REST on a platform"
 license = "GPL-3.0"
 authors = [{ name = "Matthias Kainer", email = "matthias@inxm.ai" }]

--- a/app/routes.py
+++ b/app/routes.py
@@ -22,6 +22,16 @@ import os
 import asyncio
 
 from app.utils.traced_requests import traced_request
+from app.utils.mcp_operation import (
+    MCP_METHOD_PROMPTS_GET,
+    MCP_METHOD_RESOURCES_READ,
+    MCP_METHOD_TOOLS_CALL,
+    TRANSPORT_REST,
+    classify_error_text,
+    log_sanitized_exception,
+    mcp_operation_span,
+    safe_arg_keys,
+)
 from app.utils.structured_text_parser import try_parse_structured_text
 from app.session import (
     MCPLocalSessionTask,
@@ -31,14 +41,22 @@ from app.session import (
     build_mcp_client_strategy,
 )
 from app.session_manager import mcp_session_context, session_manager
-from app.session_manager.session_context import map_tools
+from app.session_manager.session_context import (
+    ResponseTooLargeError,
+    ToolPolicyDeniedError,
+    map_tools,
+)
 from app.elicitation import (
     ElicitationRequiredError,
     InvalidUserFeedbackError,
     UnsupportedElicitationSchemaError,
     get_elicitation_coordinator,
 )
-from .oauth.user_info import get_data_access_manager
+from .oauth.user_info import (
+    CallerNotAuthorizedError,
+    ensure_caller_in_required_groups,
+    get_data_access_manager,
+)
 from opentelemetry import trace
 from .oauth.token_exchange import UserLoggedOutException
 from .oauth.token_dependency import get_access_token
@@ -225,19 +243,20 @@ async def get_resource_details(
             access_token,
         )
         incoming_headers = _extract_request_headers(request)
-        with traced_request(
-            tracer,
-            operation="get_resource_details",
+        with mcp_operation_span(
+            method=MCP_METHOD_RESOURCES_READ,
+            target=resource_name,
+            transport=TRANSPORT_REST,
             session_value=x_inxm_mcp_session,
+            access_token=access_token,
             group=group,
-            start_message=f"[Resource-Details] Getting resource details. Session: {x_inxm_mcp_session}, Group: {group}",
-        ):
+        ) as op:
             async with mcp_session_context(
                 sessions, x_inxm_mcp_session, access_token, group, incoming_headers
             ) as session:
                 result = await session.list_resources()
                 # find the resource with the given name
-                logger.debug(f"Looking for resource: {resource_name} in {result}")
+                logger.debug(f"Looking for resource: {resource_name}")
                 result = next(
                     (res for res in result.resources if res.name == resource_name), None
                 )
@@ -252,9 +271,16 @@ async def get_resource_details(
                     raise HTTPException(status_code=404, detail="Resource not found")
                 if resource.contents is None:
                     raise HTTPException(status_code=404, detail="Resource is empty")
+                op.record_success(resource)
                 resource = resource.contents[0]
-                logger.info(f"Resource retrieved: {resource}")
+                # Resource bodies are sensitive content; only the mime type
+                # may be logged.
                 mime_type = resource.mimeType or "text/plain"
+                logger.info(
+                    "[Resource-Details] Resource retrieved: %s (%s)",
+                    resource_name,
+                    mime_type,
+                )
                 if hasattr(resource, "blob"):
                     blob = resource.blob
                 else:
@@ -277,13 +303,18 @@ async def get_resource_details(
                 else:
                     return Response(status_code=204)
 
+    except ResponseTooLargeError as e:
+        # Deterministic for this call; the oversized content is never relayed.
+        raise HTTPException(status_code=HTTP_STATUS_TOOL_EXECUTION_ERROR, detail=str(e))
     except HTTPException as e:
         raise e
     except UserLoggedOutException as e:
         logger.warning(f"[Resource-Details] Unauthorized access: {str(e)}")
         raise HTTPException(status_code=401, detail=e.message)
     except Exception as e:
-        log_exception_with_details(logger, "[Resource-Details]", e)
+        # Resource bodies and downstream error messages are sensitive; only
+        # sanitized exception details reach the logs on this path.
+        log_sanitized_exception(logger, "[Resource-Details]", e)
         child_http_exception = find_exception_in_exception_groups(e, HTTPException)
         if child_http_exception:
             raise child_http_exception
@@ -482,14 +513,22 @@ async def run_tool(
                     },
                 )
         incoming_headers = _extract_request_headers(request)
-        with traced_request(
-            tracer=tracer,
-            operation="run_tool",
+        logger.info(
+            "[Tool-Call] Tool call: %s, Session: %s, Group: %s, Arg keys: %s",
+            tool_name,
+            token_fingerprint(x_inxm_mcp_session),
+            group,
+            safe_arg_keys(args),
+        )
+        with mcp_operation_span(
+            method=MCP_METHOD_TOOLS_CALL,
+            target=tool_name,
+            transport=TRANSPORT_REST,
             session_value=x_inxm_mcp_session,
+            access_token=access_token,
             group=group,
-            start_message=f"[Tool-Call] Tool call: {tool_name}, Session: {x_inxm_mcp_session}, Group: {group}, Args: {args}",
-            extra_attrs={"tool.name": tool_name},
-        ):
+            arg_keys=safe_arg_keys(args),
+        ) as op:
             async with mcp_session_context(
                 sessions, x_inxm_mcp_session, access_token, group, incoming_headers
             ) as session:
@@ -513,20 +552,29 @@ async def run_tool(
                 else:
                     result = await session.call_tool(tool_name, args, access_token)
 
-        if not result.isError:
-            if result.structuredContent:
-                logger.info(
-                    f"[Tool-Call] Result for tool {tool_name} already has structuredContent. Skipping parsing."
-                )
+            if not result.isError:
+                if result.structuredContent:
+                    logger.info(
+                        f"[Tool-Call] Result for tool {tool_name} already has structuredContent. Skipping parsing."
+                    )
+                else:
+                    for content in result.content:
+                        if hasattr(content, "text") and content.text:
+                            parsed = try_parse_structured_text(content.text)
+                            if parsed is not None:
+                                result.structuredContent = parsed
+                                break
+                op.record_success(result)
             else:
-                for content in result.content:
-                    if hasattr(content, "text") and content.text:
-                        parsed = try_parse_structured_text(content.text)
-                        if parsed is not None:
-                            result.structuredContent = parsed
-                            break
+                error_text = result.content[0].text if result.content else ""
+                op.record_error_result(classify_error_text(error_text), result)
 
-        logger.info(f"[Tool-Call] Tool {tool_name} called. Result: {result}")
+        logger.info(
+            "[Tool-Call] Tool %s called. isError=%s items=%s",
+            tool_name,
+            result.isError,
+            len(result.content) if result.content else 0,
+        )
         if result.isError:
             error_text = result.content[0].text if result.content else ""
             if "Unknown tool" in error_text:
@@ -534,7 +582,7 @@ async def run_tool(
                 raise HTTPException(status_code=404, detail=str(result))
             if "validation error" in error_text:
                 logger.info(
-                    f"[Tool-Call] Tool called with invalid parameters: {tool_name}. Result: {result}"
+                    f"[Tool-Call] Tool called with invalid parameters: {tool_name}."
                 )
                 raise HTTPException(status_code=400, detail=str(result))
 
@@ -543,20 +591,26 @@ async def run_tool(
             # flattens the exception class to prose, so the text is all we
             # have to classify on.
             if "timed out" in error_text.lower():
-                logger.warning(
-                    f"[Tool-Call] Upstream timeout in tool {tool_name}: {result}"
-                )
+                logger.warning(f"[Tool-Call] Upstream timeout in tool {tool_name}")
                 raise HTTPException(
                     status_code=HTTP_STATUS_TOOL_UPSTREAM_TIMEOUT, detail=str(result)
                 )
 
             # The tool ran and rejected the request; the bridge itself is healthy.
             # 4xx keeps callers from retrying a failure that cannot succeed.
-            logger.error(f"[Tool-Call] Error in tool {tool_name}: {result}")
+            logger.error(f"[Tool-Call] Error in tool {tool_name}")
             raise HTTPException(
                 status_code=HTTP_STATUS_TOOL_EXECUTION_ERROR, detail=str(result)
             )
         return result
+    except ToolPolicyDeniedError:
+        # Hidden tools must be indistinguishable from missing ones, and the
+        # rejection happens before any downstream contact.
+        raise HTTPException(status_code=404, detail="Tool not found")
+    except ResponseTooLargeError as e:
+        # Deterministic for this call, so it belongs in the terminal 4xx
+        # bucket; the oversized content itself is never relayed.
+        raise HTTPException(status_code=HTTP_STATUS_TOOL_EXECUTION_ERROR, detail=str(e))
     except ElicitationRequiredError as e:
         raise HTTPException(status_code=409, detail=e.to_client_payload())
     except InvalidUserFeedbackError as e:
@@ -583,8 +637,9 @@ async def run_tool(
         logger.warning(f"[Tool-Call] Unauthorized access: {str(e)}")
         raise HTTPException(status_code=401, detail=e.message)
     except Exception as e:
-        # Handle TaskGroup exceptions with multiple sub-exceptions
-        log_exception_with_details(logger, "[Tool-Call]", e)
+        # Downstream exception messages can embed request/response content,
+        # so only sanitized details reach the logs on this path.
+        log_sanitized_exception(logger, "[Tool-Call]", e)
         child_http_exception = find_exception_in_exception_groups(e, HTTPException)
         if child_http_exception:
             raise child_http_exception
@@ -616,41 +671,67 @@ async def run_prompt(
             args = dict(args)
             args.pop("inxm-session")
         incoming_headers = _extract_request_headers(request)
-        with traced_request(
-            tracer=tracer,
-            operation="run_prompt",
+        logger.info(
+            "[Prompt-Call] Prompt call: %s, Session: %s, Group: %s, Arg keys: %s",
+            prompt_name,
+            token_fingerprint(x_inxm_mcp_session),
+            group,
+            safe_arg_keys(args),
+        )
+        with mcp_operation_span(
+            method=MCP_METHOD_PROMPTS_GET,
+            target=prompt_name,
+            transport=TRANSPORT_REST,
             session_value=x_inxm_mcp_session,
+            access_token=access_token,
             group=group,
-            start_message=f"[Prompt-Call] Prompt call: {prompt_name}, Session: {x_inxm_mcp_session}, Group: {group}, Args: {args}",
-            extra_attrs={"prompt.name": prompt_name},
-        ):
+            arg_keys=safe_arg_keys(args),
+        ) as op:
             async with mcp_session_context(
                 sessions, x_inxm_mcp_session, access_token, group, incoming_headers
             ) as session:
                 result = await session.call_prompt(prompt_name, args)
 
-        logger.info(f"[Prompt-Call] Prompt {prompt_name} called. Result: {result}")
+            if result.isError:
+                # RunPromptResult carries its error text in `description`.
+                op.record_error_result(
+                    classify_error_text(result.description or ""), result
+                )
+            else:
+                op.record_success(result)
+
+        logger.info(
+            "[Prompt-Call] Prompt %s called. isError=%s", prompt_name, result.isError
+        )
         if result.isError:
-            if "Unknown prompt" in result.content[0].text:
+            # RunPromptResult has no `content` field — its error text lives in
+            # `description`. Reading `content` here raised AttributeError and
+            # collapsed every prompt failure into a generic 500.
+            error_text = result.description or ""
+            if "Unknown prompt" in error_text:
                 logger.info(f"[Prompt-Call] Prompt not found: {prompt_name}")
                 raise HTTPException(status_code=404, detail=str(result))
-            if "validation error" in result.content[0].text:
+            if "validation error" in error_text:
                 logger.info(
-                    f"[Prompt-Call] Prompt called with invalid parameters: {prompt_name}. Result: {result}"
+                    f"[Prompt-Call] Prompt called with invalid parameters: {prompt_name}."
                 )
                 raise HTTPException(status_code=400, detail=str(result))
 
-            logger.error(f"[Prompt-Call] Error in prompt {prompt_name}: {result}")
+            logger.error(f"[Prompt-Call] Error in prompt {prompt_name}")
             raise HTTPException(status_code=500, detail=str(result))
         return result
+    except ResponseTooLargeError as e:
+        # Deterministic for this call; the oversized content is never relayed.
+        raise HTTPException(status_code=HTTP_STATUS_TOOL_EXECUTION_ERROR, detail=str(e))
     except HTTPException as e:
         raise e
     except UserLoggedOutException as e:
         logger.warning(f"[Prompt-Call] Unauthorized access: {str(e)}")
         raise HTTPException(status_code=401, detail=e.message)
     except Exception as e:
-        # Handle TaskGroup exceptions with multiple sub-exceptions
-        log_exception_with_details(logger, "[Prompt-Call]", e)
+        # Downstream exception messages can embed request/response content,
+        # so only sanitized details reach the logs on this path.
+        log_sanitized_exception(logger, "[Prompt-Call]", e)
         child_http_exception = find_exception_in_exception_groups(e, HTTPException)
         if child_http_exception:
             raise child_http_exception
@@ -666,8 +747,17 @@ async def start_session(
 ):
     try:
         with tracer.start_as_current_span("start_session") as span:
+            # Same bridge-level authorization boundary as mcp_session_context:
+            # a persistent session must not be creatable by callers outside
+            # BRIDGE_REQUIRED_GROUPS.
+            try:
+                ensure_caller_in_required_groups(access_token)
+            except CallerNotAuthorizedError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.detail)
             x_inxm_mcp_session = session_id(str(uuid.uuid4()), access_token)
-            span.set_attribute("session.id", x_inxm_mcp_session)
+            # Session values embed the caller's access token; only a
+            # fingerprint may become a span attribute.
+            span.set_attribute("session.id", token_fingerprint(x_inxm_mcp_session))
             if group:
                 span.set_attribute("session.group", group)
 
@@ -755,7 +845,7 @@ async def close_session(
                 ),
                 access_token,
             )
-            span.set_attribute("session.id", x_inxm_mcp_session)
+            span.set_attribute("session.id", token_fingerprint(x_inxm_mcp_session))
             if x_inxm_mcp_session is None:
                 logger.warning("[Session] Session header missing on close.")
                 raise HTTPException(status_code=400, detail="Session header missing")

--- a/app/server.py
+++ b/app/server.py
@@ -129,8 +129,24 @@ class FilteringSpanExporter(SpanExporter if _OTEL_AVAILABLE else object):
 
 # Configure tracing if OpenTelemetry dependencies are available
 if _OTEL_AVAILABLE:
+    import os as _os
+
+    # Resource identity for deployment validation. OTEL_RESOURCE_ATTRIBUTES
+    # remains the source of truth (Resource.create merges it); these explicit
+    # keys fill in from dedicated env vars when present, omitted otherwise.
+    _resource_attributes = {"service.name": SERVICE_NAME}
+    for _attr, _env in (
+        ("service.version", "SERVICE_VERSION"),
+        ("service.instance.id", "HOSTNAME"),
+        ("deployment.environment.name", "DEPLOYMENT_ENVIRONMENT"),
+        ("enterprise_mcp_bridge.build.id", "BUILD_ID"),
+    ):
+        _value = _os.environ.get(_env, "").strip()
+        if _value:
+            _resource_attributes[_attr] = _value
+
     trace.set_tracer_provider(
-        TracerProvider(resource=Resource.create({"service.name": SERVICE_NAME}))
+        TracerProvider(resource=Resource.create(_resource_attributes))
     )
     tracer_provider = trace.get_tracer_provider()
     if OTLP_ENDPOINT:

--- a/app/session/client_strategy.py
+++ b/app/session/client_strategy.py
@@ -41,20 +41,27 @@ from app.vars import (
 logger = logging.getLogger("uvicorn.error")
 
 
-def _serialize_log_data(data: object) -> str:
-    """Render MCP log payload safely for application logs."""
+def _describe_log_data(data: object) -> str:
+    """Safe metadata about an MCP log payload — never its content.
+
+    Downstream logging notifications are arbitrary, untrusted payloads that
+    can carry request arguments, results or credentials; only their shape is
+    recorded — and the payload is never serialized, not even to measure it.
+    """
     try:
         if isinstance(data, (dict, list)):
-            return json.dumps(data, ensure_ascii=False)
-        return str(data)
+            return f"<payload type={type(data).__name__} items={len(data)}>"
+        if isinstance(data, str):
+            return f"<payload type=str chars={len(data)}>"
+        return f"<payload type={type(data).__name__}>"
     except Exception:
-        return "<unserializable MCP log payload>"
+        return f"<payload type={type(data).__name__}>"
 
 
 async def _log_mcp_notification(
     params: types.LoggingMessageNotificationParams,
 ) -> None:
-    """Forward MCP server log notifications into the application logger."""
+    """Record MCP server log notifications without their payload content."""
     log_fn = {
         "debug": logger.debug,
         "info": logger.info,
@@ -67,8 +74,10 @@ async def _log_mcp_notification(
     }.get(params.level, logger.info)
 
     logger_name = params.logger or "MCP"
-    message = _serialize_log_data(params.data)
-    log_fn(f"[MCP][{logger_name}][{params.level.upper()}] {message}")
+    log_fn(
+        f"[MCP][{logger_name}][{params.level.upper()}] "
+        f"{_describe_log_data(params.data)}"
+    )
 
 
 def _make_elicitation_callback(session_key: Optional[str]):

--- a/app/session/session.py
+++ b/app/session/session.py
@@ -10,11 +10,23 @@ from mcp import StdioServerParameters
 
 from app.elicitation import ElicitationRequiredError, InvalidUserFeedbackError
 from ..utils.exception_logging import log_exception_with_details
+from ..utils.mcp_operation import downstream_call_kwargs, safe_arg_keys
 from .client_strategy import (
     MCPClientStrategy,
     LocalMCPClientStrategy,
     build_mcp_client_strategy,
 )
+
+
+def _summarize_request(req) -> str:
+    """Loggable request summary without arguments or payload content."""
+    if isinstance(req, dict):
+        action = req.get("action", "unknown")
+        target = (
+            req.get("tool_name") or req.get("prompt_name") or req.get("resource_name")
+        )
+        return f"action={action} target={target}"
+    return str(req)
 
 
 def try_get_session_id(
@@ -111,10 +123,16 @@ class MCPSessionBase(ABC):
             await self._task
 
     async def request(self, req):
-        logger.debug(f"[{self.__class__.__name__}] Received request: {req}")
+        # Requests carry decorated arguments (including injected credentials)
+        # and responses carry tool results — neither may be logged raw.
+        logger.debug(
+            f"[{self.__class__.__name__}] Received request: {_summarize_request(req)}"
+        )
         await self.request_queue.put(req)
         response = await self.response_queue.get()
-        logger.debug(f"[{self.__class__.__name__}] Response: {response}")
+        logger.debug(
+            f"[{self.__class__.__name__}] Response type: {type(response).__name__}"
+        )
         return response
 
 
@@ -136,7 +154,9 @@ class MCPLocalSessionTask(MCPSessionBase):
                 logger.info("[MCPLocalSessionTask] MCP session established.")
                 while True:
                     req = await self.request_queue.get()
-                    logger.debug(f"[MCPLocalSessionTask] Processing request: {req}")
+                    logger.debug(
+                        f"[MCPLocalSessionTask] Processing: {_summarize_request(req)}"
+                    )
                     if req == "ping":
                         if (
                             last_trigger
@@ -204,7 +224,8 @@ class MCPLocalSessionTask(MCPSessionBase):
                         prompt_name = req["prompt_name"]
                         args = req.get("args", {})
                         logger.info(
-                            f"[MCPLocalSessionTask] Running prompt: {prompt_name} with args: {args}"
+                            f"[MCPLocalSessionTask] Running prompt: {prompt_name} "
+                            f"with arg keys: {safe_arg_keys(args)}"
                         )
                         try:
                             result = await session.get_prompt(prompt_name, args)
@@ -223,7 +244,8 @@ class MCPLocalSessionTask(MCPSessionBase):
                         progress_callback = req.get("progress_callback")
                         log_callback = req.get("log_callback")
                         logger.info(
-                            f"[MCPLocalSessionTask] Running tool with progress: {tool_name} with args: {args}"
+                            f"[MCPLocalSessionTask] Running tool with progress: {tool_name} "
+                            f"with arg keys: {safe_arg_keys(args)}"
                         )
                         try:
                             call_fn = getattr(
@@ -234,7 +256,9 @@ class MCPLocalSessionTask(MCPSessionBase):
                                     "MCP session missing call_tool implementation"
                                 )
 
-                            call_kwargs: dict[str, object] = {}
+                            call_kwargs: dict[str, object] = downstream_call_kwargs(
+                                call_fn, trace_meta=req.get("trace_meta")
+                            )
                             try:
                                 sig = inspect.signature(call_fn)
                                 if "progress_callback" in sig.parameters:
@@ -268,10 +292,18 @@ class MCPLocalSessionTask(MCPSessionBase):
                         tool_name = req["tool_name"]
                         args = req.get("args", {})
                         logger.info(
-                            f"[MCPLocalSessionTask] Running tool: {tool_name} with args: {args}"
+                            f"[MCPLocalSessionTask] Running tool: {tool_name} "
+                            f"with arg keys: {safe_arg_keys(args)}"
                         )
                         try:
-                            result = await session.call_tool(tool_name, args)
+                            result = await session.call_tool(
+                                tool_name,
+                                args,
+                                **downstream_call_kwargs(
+                                    session.call_tool,
+                                    trace_meta=req.get("trace_meta"),
+                                ),
+                            )
                             await self.response_queue.put(result)
                         except ElicitationRequiredError as exc:
                             await self.response_queue.put(exc.to_client_payload())

--- a/app/session/test_client_strategy.py
+++ b/app/session/test_client_strategy.py
@@ -412,11 +412,16 @@ async def test_mcp_log_notifications_forwarded(monkeypatch):
     await client_strategy._log_mcp_notification(params_info)
     await client_strategy._log_mcp_notification(params_error)
 
-    assert ("info", "[MCP][tools][INFO] hello") in fake_logger.messages
-    # Second call should log to error with JSON rendered payload
+    # Downstream log payloads are arbitrary untrusted content; only their
+    # shape is recorded, never the content itself.
+    assert fake_logger.messages[0][0] == "info"
+    assert fake_logger.messages[0][1].startswith("[MCP][tools][INFO]")
+    assert "hello" not in fake_logger.messages[0][1]
+    assert "type=str chars=5" in fake_logger.messages[0][1]
     assert fake_logger.messages[-1][0] == "error"
     assert "[MCP][MCP][ERROR]" in fake_logger.messages[-1][1]
-    assert '"detail": "boom"' in fake_logger.messages[-1][1]
+    assert "boom" not in fake_logger.messages[-1][1]
+    assert "type=dict" in fake_logger.messages[-1][1]
 
 
 @pytest.mark.asyncio

--- a/app/session_manager/prompt_helper.py
+++ b/app/session_manager/prompt_helper.py
@@ -7,7 +7,7 @@ from typing import Optional
 from fastapi import HTTPException
 
 from app.models import RunPromptResult
-
+from app.utils.mcp_operation import safe_arg_keys
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -122,6 +122,7 @@ async def call_prompt(call: any, prompt_name: str, args: Optional[dict] = []):
             )
         )
 
-    # Call the prompt with the provided arguments
-    logger.info(f"Calling prompt: {prompt_name} with args: {args}")
+    # Call the prompt with the provided arguments; argument values are
+    # sensitive request content and stay out of the logs.
+    logger.info(f"Calling prompt: {prompt_name} with arg keys: {safe_arg_keys(args)}")
     return await call(prompt_name, args)

--- a/app/session_manager/session_context.py
+++ b/app/session_manager/session_context.py
@@ -16,15 +16,24 @@ from app.session_manager.session_manager import SessionManagerBase
 from app.models import RunPromptResult, RunToolsResult
 from fnmatch import fnmatch
 from app.oauth.decorator import decorate_args_with_oauth_token
-from app.oauth.user_info import get_data_access_manager
+from app.oauth.user_info import (
+    CallerNotAuthorizedError,
+    ensure_caller_in_required_groups,
+    get_data_access_manager,
+)
 from app.utils import mask_token
+from app.utils.mcp_operation import (
+    build_trace_meta,
+    downstream_call_kwargs,
+    encoded_result_size,
+)
 from app.vars import (
     MCP_MAP_HEADER_TO_INPUT,
     TOOL_OUTPUT_SCHEMAS,
     MCP_BASE_PATH,
     get_tool_output_schema,
 )
-
+from app import vars as app_vars
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -73,6 +82,70 @@ def get_tool_name(tool: Any) -> Optional[str]:
     return name
 
 
+class ToolPolicyDeniedError(Exception):
+    """A tool call was rejected by the INCLUDE_TOOLS/EXCLUDE_TOOLS policy."""
+
+    def __init__(self, tool_name: str):
+        self.tool_name = tool_name
+        super().__init__(f"Tool not available: {tool_name}")
+
+
+def tool_allowed(tool_name: Optional[str]) -> bool:
+    """Single policy check shared by discovery (tools/list) and execution.
+
+    Discovery filtering alone is not a boundary: a client can call a hidden
+    tool directly, so every execution path must consult this same check.
+    """
+    if not tool_name:
+        return False
+    include_match = any(
+        matches_pattern(tool_name, pattern) for pattern in INCLUDE_TOOLS if pattern
+    )
+    exclude_match = any(
+        matches_pattern(tool_name, pattern) for pattern in EXCLUDE_TOOLS if pattern
+    )
+    if INCLUDE_TOOLS and any(INCLUDE_TOOLS) and not include_match:
+        return False
+    if EXCLUDE_TOOLS and any(EXCLUDE_TOOLS) and exclude_match:
+        return False
+    return True
+
+
+def ensure_tool_allowed(tool_name: str) -> None:
+    """Fail closed before any downstream contact for disallowed tools."""
+    if not tool_allowed(tool_name):
+        logger.warning(f"[ToolPolicy] Rejected disallowed tool call: {tool_name}")
+        raise ToolPolicyDeniedError(tool_name)
+
+
+class ResponseTooLargeError(Exception):
+    """Downstream response exceeded the configured bridge byte ceiling."""
+
+    def __init__(self, size: int, limit: int):
+        self.size = size
+        self.limit = limit
+        super().__init__(
+            f"Downstream response of {size} bytes exceeds the configured "
+            f"ceiling of {limit} bytes"
+        )
+
+
+def enforce_response_ceiling(result: Any) -> Any:
+    """Reject results larger than MCP_MAX_RESPONSE_BYTES (0 disables).
+
+    Downstream count caps do not bound every serialized response, so the
+    bridge enforces its own named byte ceiling. The oversized content is
+    dropped, never partially relayed.
+    """
+    limit = app_vars.MCP_MAX_RESPONSE_BYTES
+    if limit <= 0:
+        return result
+    size = encoded_result_size(result)
+    if size is not None and size > limit:
+        raise ResponseTooLargeError(size, limit)
+    return result
+
+
 def filter_tools(tools: Any) -> list:
     """Filter tool definitions using INCLUDE_TOOLS and EXCLUDE_TOOLS rules."""
     tool_list = _to_tool_list(tools)
@@ -81,20 +154,12 @@ def filter_tools(tools: Any) -> list:
         name = get_tool_name(tool)
         if not name:
             continue
-        include_match = any(
-            matches_pattern(name, pattern) for pattern in INCLUDE_TOOLS if pattern
-        )
-        exclude_match = any(
-            matches_pattern(name, pattern) for pattern in EXCLUDE_TOOLS if pattern
-        )
+        allowed = tool_allowed(name)
         logger.debug(
-            f"[Tools] Filter check -> Tool: {name}, Include Match: {include_match} - {INCLUDE_TOOLS}, Exclude Match: {exclude_match} - {EXCLUDE_TOOLS}"
+            f"[Tools] Filter check -> Tool: {name}, Allowed: {allowed} - include={INCLUDE_TOOLS}, exclude={EXCLUDE_TOOLS}"
         )
-        if INCLUDE_TOOLS and any(INCLUDE_TOOLS) and not include_match:
-            continue
-        if EXCLUDE_TOOLS and any(EXCLUDE_TOOLS) and exclude_match:
-            continue
-        filtered.append(tool)
+        if allowed:
+            filtered.append(tool)
     return filtered
 
 
@@ -386,6 +451,13 @@ async def mcp_session_context(
     incoming_headers: Optional[dict[str, str]] = None,
 ):
     """Yield a delegate with unified list_tools() and call_tool() across sessionful and sessionless modes."""
+    # Bridge-level authorization boundary: when BRIDGE_REQUIRED_GROUPS is set,
+    # every request through this seam is gated before any downstream contact.
+    try:
+        ensure_caller_in_required_groups(access_token)
+    except CallerNotAuthorizedError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+
     # Sessionless path: validate group access (if present) and open a transient MCP session
     if x_inxm_mcp_session is None:
         if group and access_token:
@@ -411,7 +483,9 @@ async def mcp_session_context(
                         return await list_resources(session.list_resources)
 
                     async def read_resource(self, resource_name: str):
-                        return await session.read_resource(resource_name)
+                        return enforce_response_ceiling(
+                            await session.read_resource(resource_name)
+                        )
 
                     async def list_tools(self):
                         tools = await session.list_tools()
@@ -423,6 +497,7 @@ async def mcp_session_context(
                         args: Optional[Dict],
                         access_token_inner: Optional[str],
                     ):
+                        ensure_tool_allowed(tool_name)
                         tools = await session.list_tools()
                         decorated_args = await decorate_args_with_oauth_token(
                             tools, tool_name, args, access_token_inner
@@ -431,8 +506,12 @@ async def mcp_session_context(
                         decorated_args = inject_headers_into_args(
                             tools, tool_name, decorated_args, incoming_headers
                         )
-                        result = await session.call_tool(tool_name, decorated_args)
-                        return RunToolsResult(result)
+                        result = await session.call_tool(
+                            tool_name,
+                            decorated_args,
+                            **downstream_call_kwargs(session.call_tool),
+                        )
+                        return RunToolsResult(enforce_response_ceiling(result))
 
                     async def call_tool_with_progress(
                         self,
@@ -459,6 +538,7 @@ async def mcp_session_context(
                         Returns:
                             RunToolsResult with the tool execution result
                         """
+                        ensure_tool_allowed(tool_name)
                         tools = await session.list_tools()
                         decorated_args = await decorate_args_with_oauth_token(
                             tools, tool_name, args, access_token_inner
@@ -474,7 +554,7 @@ async def mcp_session_context(
                         if not call_fn:
                             raise RuntimeError("MCP session missing call_tool")
 
-                        call_kwargs: dict[str, Any] = {}
+                        call_kwargs: dict[str, Any] = downstream_call_kwargs(call_fn)
                         try:
                             sig = inspect.signature(call_fn)
                             if "progress_callback" in sig.parameters:
@@ -488,7 +568,7 @@ async def mcp_session_context(
                                 call_kwargs["log_callback"] = log_callback
 
                         result = await call_fn(tool_name, decorated_args, **call_kwargs)
-                        return RunToolsResult(result)
+                        return RunToolsResult(enforce_response_ceiling(result))
 
                     async def call_tool_streaming(
                         self,
@@ -602,7 +682,7 @@ async def mcp_session_context(
                         result = await call_prompt(
                             session.get_prompt, prompt_name, args
                         )
-                        return RunPromptResult(result)
+                        return enforce_response_ceiling(RunPromptResult(result))
 
                 yield SessionDelegate()
         except ValueError as exc:
@@ -635,6 +715,7 @@ async def mcp_session_context(
             args: Optional[Dict],
             access_token_inner: Optional[str],
         ):
+            ensure_tool_allowed(tool_name)
             tools = await mcp_task.request("list_tools")
             decorated_args = await decorate_args_with_oauth_token(
                 tools, tool_name, args, access_token_inner
@@ -644,7 +725,14 @@ async def mcp_session_context(
                 tools, tool_name, decorated_args, incoming_headers
             )
             result = await mcp_task.request(
-                {"action": "run_tool", "tool_name": tool_name, "args": decorated_args}
+                {
+                    "action": "run_tool",
+                    "tool_name": tool_name,
+                    "args": decorated_args,
+                    # Trace context is captured here because the session task
+                    # runs outside this request's span context.
+                    "trace_meta": build_trace_meta(),
+                }
             )
             if isinstance(result, dict):
                 if result.get("error") == "feedback_required":
@@ -659,7 +747,7 @@ async def mcp_session_context(
                         session_key=x_inxm_mcp_session,
                         payload=result.get("elicitation") or {},
                     )
-            return RunToolsResult(result)
+            return RunToolsResult(enforce_response_ceiling(result))
 
         async def call_tool_with_progress(
             self,
@@ -682,6 +770,7 @@ async def mcp_session_context(
             Returns:
                 RunToolsResult with the tool execution result
             """
+            ensure_tool_allowed(tool_name)
             tools = await mcp_task.request("list_tools")
             decorated_args = await decorate_args_with_oauth_token(
                 tools, tool_name, args, access_token_inner
@@ -696,6 +785,7 @@ async def mcp_session_context(
                     "args": decorated_args,
                     "progress_callback": progress_callback,
                     "log_callback": log_callback,
+                    "trace_meta": build_trace_meta(),
                 }
             )
             if isinstance(result, dict):
@@ -711,7 +801,7 @@ async def mcp_session_context(
                         session_key=x_inxm_mcp_session,
                         payload=result.get("elicitation") or {},
                     )
-            return RunToolsResult(result)
+            return RunToolsResult(enforce_response_ceiling(result))
 
         async def call_tool_streaming(
             self,
@@ -828,8 +918,10 @@ async def mcp_session_context(
             return await list_resources(request)
 
         async def read_resource(self, resource_name: str):
-            return await mcp_task.request(
-                {"action": "read_resource", "resource_name": resource_name}
+            return enforce_response_ceiling(
+                await mcp_task.request(
+                    {"action": "read_resource", "resource_name": resource_name}
+                )
             )
 
         async def call_prompt(
@@ -842,7 +934,9 @@ async def mcp_session_context(
                     {"action": "get_prompt", "prompt_name": prompt_name, "args": args}
                 )
 
-            return RunPromptResult(await call_prompt(request, prompt_name, args))
+            return enforce_response_ceiling(
+                RunPromptResult(await call_prompt(request, prompt_name, args))
+            )
 
     try:
         yield TaskDelegate()

--- a/app/sse/mcp_proxy.py
+++ b/app/sse/mcp_proxy.py
@@ -27,12 +27,29 @@ from mcp.server.lowlevel.server import request_ctx as lowlevel_request_ctx
 
 from app.elicitation import ElicitationRequiredError, get_elicitation_coordinator
 from app.oauth.decorator import decorate_args_with_oauth_token
+from app.oauth.user_info import (
+    CallerNotAuthorizedError,
+    ensure_caller_in_required_groups,
+)
 from app.session import mcp_session
 from app.session_manager.session_context import (
     _to_tool_list,
+    enforce_response_ceiling,
+    ensure_tool_allowed,
     filter_tools,
     inject_headers_into_args,
     list_resources as _list_resources_helper,
+)
+from app.utils.mcp_operation import (
+    MCP_METHOD_PROMPTS_GET,
+    MCP_METHOD_RESOURCES_READ,
+    MCP_METHOD_TOOLS_CALL,
+    TRANSPORT_SSE,
+    classify_error_text,
+    downstream_call_kwargs,
+    log_sanitized_exception,
+    mcp_operation_span,
+    safe_arg_keys,
 )
 from app.vars import (
     MCP_BASE_PATH,
@@ -77,6 +94,36 @@ def _extract_access_token(request: Request) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
+def _request_telemetry_context() -> dict:
+    """Best-effort request/client identifiers from the low-level MCP context.
+
+    Missing context is omitted, never fabricated; nothing here reads request
+    arguments or results.
+    """
+    info: dict = {
+        "request_id": None,
+        "protocol_version": None,
+        "client_name": None,
+        "client_version": None,
+    }
+    ctx = lowlevel_request_ctx.get(None)
+    if ctx is None:
+        return info
+    request_id = getattr(ctx, "request_id", None)
+    if request_id is not None:
+        info["request_id"] = str(request_id)
+    client_params = getattr(getattr(ctx, "session", None), "client_params", None)
+    if client_params is not None:
+        protocol_version = getattr(client_params, "protocolVersion", None)
+        if protocol_version:
+            info["protocol_version"] = str(protocol_version)
+        client_info = getattr(client_params, "clientInfo", None)
+        if client_info is not None:
+            info["client_name"] = getattr(client_info, "name", None)
+            info["client_version"] = getattr(client_info, "version", None)
+    return info
+
+
 def _build_proxy_server(
     downstream,
     access_token: Optional[str],
@@ -94,32 +141,56 @@ def _build_proxy_server(
 
     @proxy.call_tool(validate_input=False)
     async def _call_tool(name: str, arguments: dict) -> types.CallToolResult:
-        tools = await downstream.list_tools()
-        args = await decorate_args_with_oauth_token(
-            tools, name, arguments, access_token
-        )
-        args = inject_headers_into_args(tools, name, args, incoming_headers)
-        for _ in range(3):
-            try:
-                return await downstream.call_tool(name, args)
-            except ElicitationRequiredError as exc:
-                if not session_key:
-                    raise
-                ctx = lowlevel_request_ctx.get(None)
-                if not ctx or not getattr(ctx, "session", None):
-                    raise
-                client_result = await ctx.session.elicit(
-                    message=str(exc.payload.get("message") or ""),
-                    requestedSchema=exc.payload.get("requestedSchema") or {},
-                )
-                coordinator.submit_response(
-                    session_key,
-                    {
-                        "action": client_result.action,
-                        "content": client_result.content,
-                    },
-                )
-        raise RuntimeError("Elicitation retry limit exceeded for proxied tool call")
+        with mcp_operation_span(
+            method=MCP_METHOD_TOOLS_CALL,
+            target=name,
+            transport=TRANSPORT_SSE,
+            session_value=session_key,
+            access_token=access_token,
+            arg_keys=safe_arg_keys(arguments),
+            **_request_telemetry_context(),
+        ) as op:
+            # Discovery filtering alone is bypassable by a direct call, so the
+            # same policy check runs before any downstream contact.
+            ensure_tool_allowed(name)
+            tools = await downstream.list_tools()
+            args = await decorate_args_with_oauth_token(
+                tools, name, arguments, access_token
+            )
+            args = inject_headers_into_args(tools, name, args, incoming_headers)
+            for _ in range(3):
+                try:
+                    result = await downstream.call_tool(
+                        name,
+                        args,
+                        **downstream_call_kwargs(downstream.call_tool),
+                    )
+                    result = enforce_response_ceiling(result)
+                    if getattr(result, "isError", False):
+                        content = getattr(result, "content", None)
+                        error_text = content[0].text if content else ""
+                        op.record_error_result(classify_error_text(error_text), result)
+                    else:
+                        op.record_success(result)
+                    return result
+                except ElicitationRequiredError as exc:
+                    if not session_key:
+                        raise
+                    ctx = lowlevel_request_ctx.get(None)
+                    if not ctx or not getattr(ctx, "session", None):
+                        raise
+                    client_result = await ctx.session.elicit(
+                        message=str(exc.payload.get("message") or ""),
+                        requestedSchema=exc.payload.get("requestedSchema") or {},
+                    )
+                    coordinator.submit_response(
+                        session_key,
+                        {
+                            "action": client_result.action,
+                            "content": client_result.content,
+                        },
+                    )
+            raise RuntimeError("Elicitation retry limit exceeded for proxied tool call")
 
     @proxy.list_prompts()
     async def _list_prompts() -> list[types.Prompt]:
@@ -130,7 +201,20 @@ def _build_proxy_server(
     async def _get_prompt(
         name: str, arguments: dict[str, str] | None
     ) -> types.GetPromptResult:
-        return await downstream.get_prompt(name, arguments)
+        with mcp_operation_span(
+            method=MCP_METHOD_PROMPTS_GET,
+            target=name,
+            transport=TRANSPORT_SSE,
+            session_value=session_key,
+            access_token=access_token,
+            arg_keys=safe_arg_keys(arguments),
+            **_request_telemetry_context(),
+        ) as op:
+            result = enforce_response_ceiling(
+                await downstream.get_prompt(name, arguments)
+            )
+            op.record_success(result)
+            return result
 
     @proxy.list_resources()
     async def _list_resources() -> list[types.Resource]:
@@ -139,8 +223,18 @@ def _build_proxy_server(
 
     # read_resource – register handler directly for clean result pass-through
     async def _read_resource_handler(req: types.ReadResourceRequest):
-        result = await downstream.read_resource(req.params.uri)
-        return types.ServerResult(result)
+        with mcp_operation_span(
+            method=MCP_METHOD_RESOURCES_READ,
+            transport=TRANSPORT_SSE,
+            session_value=session_key,
+            access_token=access_token,
+            **_request_telemetry_context(),
+        ) as op:
+            result = enforce_response_ceiling(
+                await downstream.read_resource(req.params.uri)
+            )
+            op.record_success(result)
+            return types.ServerResult(result)
 
     proxy.request_handlers[types.ReadResourceRequest] = _read_resource_handler
 
@@ -164,6 +258,16 @@ class _SSEConnectionApp:
         access_token = _extract_access_token(request)
         group = request.query_params.get("group")
         incoming_headers = dict(request.headers)
+
+        # Bridge-level authorization boundary (BRIDGE_REQUIRED_GROUPS): reject
+        # before the SSE stream opens so the client gets a proper HTTP status.
+        try:
+            ensure_caller_in_required_groups(access_token)
+        except CallerNotAuthorizedError as exc:
+            logger.warning(f"[MCP-SSE] Connection rejected: {exc.detail}")
+            resp = Response(exc.detail, status_code=exc.status_code)
+            await resp(scope, receive, send)
+            return
 
         # Validate group access *before* opening the SSE stream so we can
         # return a proper HTTP error response.
@@ -207,7 +311,8 @@ class _SSEConnectionApp:
                         proxy.create_initialization_options(),
                     )
         except Exception as exc:
-            logger.error(f"[MCP-SSE] SSE session error: {exc}")
+            # Session errors can wrap downstream content; keep them sanitized.
+            log_sanitized_exception(logger, "[MCP-SSE]", exc)
 
 
 class _SSEMessagesApp:

--- a/app/sse/routes.py
+++ b/app/sse/routes.py
@@ -21,6 +21,13 @@ from app.utils.exception_logging import (
     log_exception_with_details,
 )
 from app.utils import token_fingerprint
+from app.utils.mcp_operation import (
+    MCP_METHOD_TOOLS_CALL,
+    TRANSPORT_REST,
+    classify_error_text,
+    mcp_operation_span,
+    safe_arg_keys,
+)
 from app.vars import SESSION_FIELD_NAME
 from app.sse import stream_tool_call, create_sse_response
 from opentelemetry import trace
@@ -152,7 +159,9 @@ async def run_tool_with_progress(
                     group,
                     incoming_headers,
                 ) as session:
-                    # Create a streaming tool call function
+                    # Create a streaming tool call function. The canonical
+                    # operation span wraps the awaited call (not the SSE
+                    # generator) so it never spans across stream yields.
                     async def call_tool_with_callbacks(
                         name: str,
                         tool_args: Dict[str, Any],
@@ -160,13 +169,31 @@ async def run_tool_with_progress(
                         progress_callback,
                         log_callback,
                     ):
-                        return await session.call_tool_with_progress(
-                            name,
-                            tool_args,
-                            token,
-                            progress_callback=progress_callback,
-                            log_callback=log_callback,
-                        )
+                        with mcp_operation_span(
+                            method=MCP_METHOD_TOOLS_CALL,
+                            target=name,
+                            transport=TRANSPORT_REST,
+                            session_value=x_inxm_mcp_session,
+                            access_token=token,
+                            group=group,
+                            arg_keys=safe_arg_keys(tool_args),
+                        ) as op:
+                            result = await session.call_tool_with_progress(
+                                name,
+                                tool_args,
+                                token,
+                                progress_callback=progress_callback,
+                                log_callback=log_callback,
+                            )
+                            if getattr(result, "isError", False):
+                                content = getattr(result, "content", None)
+                                error_text = content[0].text if content else ""
+                                op.record_error_result(
+                                    classify_error_text(error_text), result
+                                )
+                            else:
+                                op.record_success(result)
+                            return result
 
                     # Stream the tool call events
                     async for event in stream_tool_call(

--- a/app/sse/test_mcp_proxy_policy_telemetry.py
+++ b/app/sse/test_mcp_proxy_policy_telemetry.py
@@ -1,0 +1,310 @@
+"""SSE proxy: execution-time tool policy and canonical operation spans.
+
+The MCP SSE transport must behave exactly like the REST compatibility routes:
+hidden/denied tools fail before any downstream contact, one canonical wide
+span is emitted per JSON-RPC request, trace context is injected into _meta,
+and canary content never reaches logs or spans.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp import types
+
+from app.session_manager import session_context
+from app.sse.mcp_proxy import _build_proxy_server
+from app.utils import mcp_operation
+from app.utils_tests.recording_tracer import RecordingTracer, span_payload_text
+
+CANARY_SECRET = "canary-secret-XYZZY-9f8e7d"
+
+
+def _make_mock_downstream(result_text="result"):
+    downstream = AsyncMock()
+    tool = types.Tool(
+        name="allowed_tool",
+        description="A test tool",
+        inputSchema={"type": "object", "properties": {"x": {"type": "string"}}},
+    )
+    downstream.list_tools.return_value = SimpleNamespace(tools=[tool])
+    downstream.call_tool.return_value = types.CallToolResult(
+        content=[types.TextContent(type="text", text=result_text)],
+        isError=False,
+    )
+    downstream.get_prompt.return_value = types.GetPromptResult(
+        messages=[
+            types.PromptMessage(
+                role="assistant",
+                content=types.TextContent(type="text", text="hello"),
+            )
+        ]
+    )
+    downstream.read_resource.return_value = types.ReadResourceResult(contents=[])
+    return downstream
+
+
+def _build(downstream):
+    return _build_proxy_server(
+        downstream,
+        access_token=None,
+        incoming_headers=None,
+        session_key="sess-1",
+    )
+
+
+def _call_tool_request(name, arguments=None):
+    return types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name=name, arguments=arguments or {}),
+    )
+
+
+@pytest.fixture
+def recording_tracer(monkeypatch):
+    tracer = RecordingTracer()
+    monkeypatch.setattr(mcp_operation, "_tracer", tracer)
+    return tracer
+
+
+@pytest.fixture
+def pilot_allowlist(monkeypatch):
+    monkeypatch.setattr(session_context, "INCLUDE_TOOLS", ["allowed_tool"])
+    monkeypatch.setattr(session_context, "EXCLUDE_TOOLS", [])
+
+
+@pytest.fixture
+def capture_logs(caplog):
+    logger = logging.getLogger("uvicorn.error")
+    previous = logger.propagate
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG, logger="uvicorn.error")
+    yield caplog
+    logger.propagate = previous
+
+
+class TestExecutionTimePolicy:
+    @pytest.mark.asyncio
+    async def test_direct_call_to_hidden_tool_fails_before_downstream(
+        self, pilot_allowlist, recording_tracer
+    ):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("hidden_tool", {"x": "v"}))
+
+        assert result.root.isError
+        # The SDK refreshes its tool cache (a discovery call) before invoking
+        # the handler; what must never happen is the execution itself.
+        downstream.call_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_fails_before_downstream(
+        self, pilot_allowlist, recording_tracer
+    ):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("get_span_details"))
+
+        assert result.root.isError
+        downstream.call_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allowed_tool_passes(self, pilot_allowlist, recording_tracer):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("allowed_tool", {"x": "v"}))
+
+        assert not result.root.isError
+        downstream.call_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_denied_call_is_classified_as_authorization(
+        self, pilot_allowlist, recording_tracer
+    ):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        await handler(_call_tool_request("hidden_tool"))
+
+        span = next(
+            s for s in recording_tracer.spans if s.name == "tools/call hidden_tool"
+        )
+        assert span.attributes["error.type"] == "authorization_error"
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "error"
+
+
+class TestCanonicalSpan:
+    @pytest.mark.asyncio
+    async def test_call_tool_emits_one_canonical_span(self, recording_tracer):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        await handler(_call_tool_request("allowed_tool", {"x": "v"}))
+
+        spans = [
+            s for s in recording_tracer.spans if s.name == "tools/call allowed_tool"
+        ]
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes["mcp.method.name"] == "tools/call"
+        assert span.attributes["gen_ai.tool.name"] == "allowed_tool"
+        assert span.attributes["enterprise_mcp_bridge.transport"] == "sse"
+        assert span.attributes["enterprise_mcp_bridge.argument.keys"] == ["x"]
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_emits_canonical_span(self, recording_tracer):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.GetPromptRequest]
+
+        await handler(
+            types.GetPromptRequest(
+                method="prompts/get",
+                params=types.GetPromptRequestParams(
+                    name="my_prompt", arguments={"topic": CANARY_SECRET}
+                ),
+            )
+        )
+
+        span = next(
+            s for s in recording_tracer.spans if s.name == "prompts/get my_prompt"
+        )
+        assert span.attributes["mcp.method.name"] == "prompts/get"
+        assert span.attributes["enterprise_mcp_bridge.argument.keys"] == ["topic"]
+        assert CANARY_SECRET not in span_payload_text(span)
+
+    @pytest.mark.asyncio
+    async def test_read_resource_emits_canonical_span(self, recording_tracer):
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.ReadResourceRequest]
+
+        await handler(
+            types.ReadResourceRequest(
+                method="resources/read",
+                params=types.ReadResourceRequestParams(uri="file:///demo.txt"),
+            )
+        )
+
+        span = next(s for s in recording_tracer.spans if s.name == "resources/read")
+        assert span.attributes["mcp.method.name"] == "resources/read"
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"
+
+
+class TestSseCanary:
+    @pytest.mark.asyncio
+    async def test_canary_args_and_results_stay_out_of_logs_and_spans(
+        self, recording_tracer, capture_logs
+    ):
+        downstream = _make_mock_downstream(result_text=f"payload {CANARY_SECRET}")
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("allowed_tool", {"x": CANARY_SECRET}))
+
+        # API contract: the client still receives the result.
+        assert CANARY_SECRET in result.root.content[0].text
+        assert CANARY_SECRET not in capture_logs.text
+        for span in recording_tracer.spans:
+            assert CANARY_SECRET not in span_payload_text(span)
+
+    @pytest.mark.asyncio
+    async def test_downstream_exception_is_sanitized(
+        self, recording_tracer, capture_logs
+    ):
+        downstream = _make_mock_downstream()
+        downstream.call_tool.side_effect = RuntimeError(f"boom {CANARY_SECRET}")
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("allowed_tool"))
+
+        assert result.root.isError
+        assert CANARY_SECRET not in capture_logs.text
+        span = next(
+            s for s in recording_tracer.spans if s.name == "tools/call allowed_tool"
+        )
+        assert span.attributes["error.type"] == "bridge_internal_error"
+        assert CANARY_SECRET not in span_payload_text(span)
+
+
+class TestTraceMetaPropagation:
+    @pytest.mark.asyncio
+    async def test_trace_context_reaches_downstream_in_meta(
+        self, recording_tracer, monkeypatch
+    ):
+        def fake_inject(carrier):
+            carrier["traceparent"] = "00-feedface-cafebabe-01"
+
+        monkeypatch.setattr(mcp_operation, "inject", fake_inject)
+        monkeypatch.setattr(mcp_operation, "MCP_TRACE_BAGGAGE_ALLOWLIST", ["group.id"])
+        monkeypatch.setattr(
+            mcp_operation.baggage,
+            "get_all",
+            lambda: {"group.id": "obs", "evil.baggage": CANARY_SECRET},
+        )
+
+        downstream = _make_mock_downstream()
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        await handler(_call_tool_request("allowed_tool", {"x": "v"}))
+
+        meta = downstream.call_tool.await_args.kwargs.get("meta")
+        assert meta["traceparent"] == "00-feedface-cafebabe-01"
+        assert meta["baggage"] == "group.id=obs"
+        assert CANARY_SECRET not in str(meta)
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_is_rejected(self, recording_tracer, monkeypatch):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 64)
+        downstream = _make_mock_downstream()
+        downstream.get_prompt.return_value = types.GetPromptResult(
+            messages=[
+                types.PromptMessage(
+                    role="assistant",
+                    content=types.TextContent(type="text", text="p" * 5000),
+                )
+            ]
+        )
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.GetPromptRequest]
+
+        with pytest.raises(Exception) as excinfo:
+            await handler(
+                types.GetPromptRequest(
+                    method="prompts/get",
+                    params=types.GetPromptRequestParams(name="my_prompt"),
+                )
+            )
+        assert "ceiling" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_oversized_response_is_rejected(self, recording_tracer, monkeypatch):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 32)
+        downstream = _make_mock_downstream(result_text="y" * 500)
+        proxy = _build(downstream)
+        handler = proxy.request_handlers[types.CallToolRequest]
+
+        result = await handler(_call_tool_request("allowed_tool"))
+
+        assert result.root.isError
+        assert "y" * 500 not in str(result.root.content)
+        span = next(
+            s for s in recording_tracer.spans if s.name == "tools/call allowed_tool"
+        )
+        assert span.attributes["error.type"] == "response_too_large"

--- a/app/test_bridge_required_groups.py
+++ b/app/test_bridge_required_groups.py
@@ -1,0 +1,316 @@
+"""Bridge-level caller authorization (BRIDGE_REQUIRED_GROUPS).
+
+The bridge itself — not only its ingress — must enforce the operator group
+boundary, and it must do so on VERIFIED claims: the bridge accepts direct
+Bearer tokens, so a forged but syntactically valid JWT claiming
+`groups: ["operators"]` must never pass. With the gate configured, a
+caller without identity gets 401, an unverifiable token gets 401, an
+authenticated caller outside the required groups gets 403 before any
+downstream contact, and members pass. Default (unset) keeps today's
+behaviour.
+"""
+
+from contextlib import asynccontextmanager
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from app import vars as app_vars
+from app.oauth import token_exchange
+from app.oauth.token_exchange import UserLoggedOutException
+from app.oauth.user_info import (
+    CallerNotAuthorizedError,
+    ensure_caller_in_required_groups,
+)
+from app.server import app as fastapi_app
+from app.session_manager import session_context
+
+TOKEN_HEADER = "X-Auth-Request-Access-Token"
+
+
+def _token(groups):
+    return jwt.encode(
+        {"sub": "user-42", "groups": groups, "azp": "web-client"},
+        "test-signing-key",
+        algorithm="HS256",
+    )
+
+
+IN_GROUP_TOKEN = _token(["operators", "employees"])
+OUT_OF_GROUP_TOKEN = _token(["marketing"])
+# Same group claim as a member, but nothing this bridge can verify — the gate
+# must reject it on verification, never trust the embedded groups.
+FORGED_TOKEN = jwt.encode(
+    {"sub": "attacker", "groups": ["operators"], "azp": "web-client"},
+    "attacker-key",
+    algorithm="HS256",
+)
+
+
+@pytest.fixture
+def fake_verifier(monkeypatch):
+    """Stand-in for JWKS verification: trusts the two well-known test tokens,
+    rejects everything else — mirroring what real verification guarantees."""
+
+    def _verify(token, *, allowed_clients, allowlist_name):
+        if not allowed_clients:
+            raise UserLoggedOutException(f"{allowlist_name} is not configured")
+        if token in (IN_GROUP_TOKEN, OUT_OF_GROUP_TOKEN):
+            return jwt.decode(token, options={"verify_signature": False})
+        raise UserLoggedOutException("Access token failed verification")
+
+    monkeypatch.setattr(token_exchange, "verified_caller_claims", _verify)
+    return _verify
+
+
+class FakeContent:
+    def __init__(self, text):
+        self.text = text
+        self.type = "text"
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = 0
+
+    async def list_tools(self):
+        self.calls += 1
+
+        class Tool:
+            name = "test_tool"
+            inputSchema = {"properties": {}}
+
+        class Container:
+            tools = [Tool()]
+
+        return Container()
+
+    async def call_tool(self, name, arguments=None, *, meta=None):
+        self.calls += 1
+
+        class Result:
+            isError = False
+            content = [FakeContent("ok")]
+            structuredContent = None
+
+        return Result()
+
+
+@pytest.fixture
+def client():
+    return TestClient(fastapi_app)
+
+
+@pytest.fixture
+def required_groups(monkeypatch):
+    monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", ["operators"])
+    monkeypatch.setattr(app_vars, "BRIDGE_ALLOWED_CLIENTS", ["web-client"])
+
+
+@pytest.fixture
+def fake_downstream(monkeypatch):
+    fake = FakeSession()
+
+    @asynccontextmanager
+    async def fake_mcp_session(**_kwargs):
+        yield fake
+
+    monkeypatch.setattr(session_context, "mcp_session", fake_mcp_session)
+    return fake
+
+
+class TestGateUnit:
+    def test_disabled_gate_is_noop(self, monkeypatch):
+        monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", [])
+        ensure_caller_in_required_groups(None)
+        ensure_caller_in_required_groups(OUT_OF_GROUP_TOKEN)
+
+    def test_missing_token_is_401(self, required_groups, fake_verifier):
+        with pytest.raises(CallerNotAuthorizedError) as excinfo:
+            ensure_caller_in_required_groups(None)
+        assert excinfo.value.status_code == 401
+
+    def test_forged_token_with_matching_groups_is_401(
+        self, required_groups, monkeypatch
+    ):
+        """The REAL verifier runs: a signed-format token this realm never
+        issued must fail verification before its group claims are read."""
+        monkeypatch.setattr(token_exchange, "_jwks_client", None)
+        with pytest.raises(CallerNotAuthorizedError) as excinfo:
+            ensure_caller_in_required_groups(FORGED_TOKEN)
+        assert excinfo.value.status_code == 401
+
+    def test_unconfigured_client_allowlist_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", ["operators"])
+        monkeypatch.setattr(app_vars, "BRIDGE_ALLOWED_CLIENTS", [])
+        monkeypatch.setattr(token_exchange, "_jwks_client", None)
+        with pytest.raises(CallerNotAuthorizedError) as excinfo:
+            ensure_caller_in_required_groups(IN_GROUP_TOKEN)
+        assert excinfo.value.status_code == 401
+
+    def test_out_of_group_is_403(self, required_groups, fake_verifier):
+        with pytest.raises(CallerNotAuthorizedError) as excinfo:
+            ensure_caller_in_required_groups(OUT_OF_GROUP_TOKEN)
+        assert excinfo.value.status_code == 403
+
+    def test_member_passes(self, required_groups, fake_verifier):
+        ensure_caller_in_required_groups(IN_GROUP_TOKEN)
+
+    def test_realm_role_membership_counts(self, required_groups, monkeypatch):
+        claims = {
+            "sub": "u",
+            "realm_access": {"roles": ["operators"]},
+            "azp": "web-client",
+        }
+        monkeypatch.setattr(
+            token_exchange, "verified_caller_claims", lambda *a, **k: claims
+        )
+        ensure_caller_in_required_groups("any-token")
+
+
+class TestVerifiedCallerClaims:
+    """The shared verifier itself: explicit client policy, signature-first."""
+
+    def test_client_allowlist_is_explicit_per_caller(self, monkeypatch):
+        from app.oauth.token_exchange import verified_caller_claims
+
+        class OkJwks:
+            def get_signing_key_from_jwt(self, token):
+                class K:
+                    key = "irrelevant"
+
+                return K()
+
+        monkeypatch.setattr(token_exchange, "_get_jwks_client", lambda: OkJwks())
+        monkeypatch.setattr(
+            token_exchange.jwt,
+            "decode",
+            lambda *a, **k: {
+                "iss": f"{token_exchange.AUTH_BASE_URL}/realms/{token_exchange.KEYCLOAK_REALM}",
+                "azp": "bridge-client",
+            },
+        )
+        claims = verified_caller_claims(
+            "token", allowed_clients=["bridge-client"], allowlist_name="X"
+        )
+        assert claims["azp"] == "bridge-client"
+        with pytest.raises(UserLoggedOutException):
+            verified_caller_claims(
+                "token", allowed_clients=["other"], allowlist_name="X"
+            )
+        with pytest.raises(UserLoggedOutException):
+            verified_caller_claims("token", allowed_clients=[], allowlist_name="X")
+
+
+class TestRestGate:
+    def test_out_of_group_caller_is_denied_before_downstream(
+        self, client, required_groups, fake_verifier, fake_downstream
+    ):
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: OUT_OF_GROUP_TOKEN},
+            json={},
+        )
+        assert response.status_code == 403
+        assert fake_downstream.calls == 0
+
+    def test_forged_token_is_denied_before_downstream(
+        self, client, required_groups, fake_verifier, fake_downstream
+    ):
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: FORGED_TOKEN},
+            json={},
+        )
+        assert response.status_code == 401
+        assert fake_downstream.calls == 0
+
+    def test_anonymous_caller_is_denied(
+        self, client, required_groups, fake_verifier, fake_downstream
+    ):
+        response = client.post("/tools/test_tool", json={})
+        assert response.status_code == 401
+        assert fake_downstream.calls == 0
+
+    def test_member_passes_through(
+        self, client, required_groups, fake_verifier, fake_downstream
+    ):
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: IN_GROUP_TOKEN},
+            json={},
+        )
+        assert response.status_code == 200
+        assert fake_downstream.calls > 0
+
+    def test_listing_is_gated_too(
+        self, client, required_groups, fake_verifier, fake_downstream
+    ):
+        response = client.get("/tools", headers={TOKEN_HEADER: OUT_OF_GROUP_TOKEN})
+        assert response.status_code == 403
+        assert fake_downstream.calls == 0
+
+    def test_session_start_is_gated(self, client, required_groups, fake_verifier):
+        response = client.post(
+            "/session/start", headers={TOKEN_HEADER: OUT_OF_GROUP_TOKEN}
+        )
+        assert response.status_code == 403
+
+    def test_default_unset_keeps_current_behaviour(
+        self, client, monkeypatch, fake_downstream
+    ):
+        monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", [])
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: OUT_OF_GROUP_TOKEN},
+            json={},
+        )
+        assert response.status_code == 200
+
+
+class TestSseGate:
+    async def _connect(self, token):
+        from app.sse.mcp_proxy import _SSEConnectionApp
+
+        sent = []
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            sent.append(message)
+
+        headers = []
+        if token is not None:
+            headers.append((TOKEN_HEADER.lower().encode(), token.encode()))
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/sse",
+            "query_string": b"",
+            "headers": headers,
+        }
+        await _SSEConnectionApp()(scope, receive, send)
+        return next(m for m in sent if m["type"] == "http.response.start")
+
+    @pytest.mark.asyncio
+    async def test_sse_connection_rejected_for_out_of_group(
+        self, required_groups, fake_verifier
+    ):
+        start = await self._connect(OUT_OF_GROUP_TOKEN)
+        assert start["status"] == 403
+
+    @pytest.mark.asyncio
+    async def test_sse_connection_rejected_for_forged_token(
+        self, required_groups, fake_verifier
+    ):
+        start = await self._connect(FORGED_TOKEN)
+        assert start["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_sse_connection_rejected_anonymous(
+        self, required_groups, fake_verifier
+    ):
+        start = await self._connect(None)
+        assert start["status"] == 401

--- a/app/test_mcp_canary_telemetry.py
+++ b/app/test_mcp_canary_telemetry.py
@@ -1,0 +1,523 @@
+"""Canary-secret tests for the MCP request paths.
+
+A synthetic credential/PII marker is planted in tool arguments, results,
+access tokens, downstream exception messages and downstream log
+notifications. It must never appear in captured application logs or in the
+attributes/events of recorded spans — on success and failure paths alike.
+
+The API response itself intentionally still carries results and error
+details: this suite guards telemetry, not the tool contract.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from app.server import app as fastapi_app
+from app.session_manager import session_context
+from app.utils import mcp_operation
+from app.utils_tests.recording_tracer import RecordingTracer, span_payload_text
+
+CANARY_SECRET = "canary-secret-XYZZY-9f8e7d"
+CANARY_EMAIL = "canary.user@example.com"
+CANARY_DOWNSTREAM_LOG = "canary-downstream-log-payload-31337"
+ACCESS_TOKEN = jwt.encode(
+    {"sub": "user-42", "email": CANARY_EMAIL, "preferred_username": "canary.user"},
+    "canary-signing-key",
+    algorithm="HS256",
+)
+TOKEN_HEADER = "X-Auth-Request-Access-Token"
+
+
+class FakeContent:
+    def __init__(self, text):
+        self.text = text
+        self.type = "text"
+
+    def __repr__(self):
+        return f"FakeContent(text={self.text!r})"
+
+
+class FakeToolsContainer:
+    def __init__(self, tools):
+        self.tools = tools
+
+
+class FakeTool:
+    def __init__(self, name, input_schema=None):
+        self.name = name
+        self.inputSchema = input_schema or {"properties": {"query": {}}}
+
+
+class FakeCallToolResult:
+    def __init__(self, is_error, text):
+        self.isError = is_error
+        self.content = [FakeContent(text)]
+        self.structuredContent = None
+
+    def __repr__(self):
+        return f"FakeCallToolResult(isError={self.isError}, content={self.content!r})"
+
+
+class FakeClientSession:
+    """Downstream MCP session double recording what actually reached it."""
+
+    def __init__(self, result=None, call_error=None):
+        self.result = result
+        self.call_error = call_error
+        self.calls = []
+
+    async def list_tools(self):
+        return FakeToolsContainer([FakeTool("test_tool")])
+
+    async def call_tool(self, name, arguments=None, *, meta=None):
+        self.calls.append({"name": name, "arguments": arguments, "meta": meta})
+        if self.call_error is not None:
+            raise self.call_error
+        return self.result
+
+    async def get_prompt(self, name, arguments=None):
+        raise AssertionError("not used in this suite")
+
+
+@pytest.fixture
+def capture_logs(caplog):
+    """uvicorn.error has propagate=False in app setup; caplog needs it on."""
+    logger = logging.getLogger("uvicorn.error")
+    previous = logger.propagate
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG, logger="uvicorn.error")
+    yield caplog
+    logger.propagate = previous
+
+
+@pytest.fixture
+def recording_tracer(monkeypatch):
+    tracer = RecordingTracer()
+    monkeypatch.setattr(mcp_operation, "_tracer", tracer)
+    return tracer
+
+
+@pytest.fixture
+def client():
+    return TestClient(fastapi_app)
+
+
+def _install_fake_session(monkeypatch, fake_session):
+    @asynccontextmanager
+    async def fake_mcp_session(**_kwargs):
+        yield fake_session
+
+    monkeypatch.setattr(session_context, "mcp_session", fake_mcp_session)
+
+
+def _all_span_text(tracer):
+    return "\n".join(span_payload_text(span) for span in tracer.spans)
+
+
+def _assert_canaries_absent(text):
+    assert CANARY_SECRET not in text
+    assert CANARY_EMAIL not in text
+    assert ACCESS_TOKEN not in text
+
+
+class TestRestToolCallCanary:
+    def test_success_path_leaks_nothing_to_logs_or_spans(
+        self, client, monkeypatch, capture_logs, recording_tracer
+    ):
+        fake = FakeClientSession(
+            result=FakeCallToolResult(False, f"result with {CANARY_SECRET}")
+        )
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"query": CANARY_SECRET, "email": CANARY_EMAIL},
+        )
+
+        assert response.status_code == 200
+        # API contract preserved: the caller still receives the result.
+        assert CANARY_SECRET in response.text
+        # The canary arguments reached the downstream server unchanged.
+        assert fake.calls[0]["arguments"]["query"] == CANARY_SECRET
+
+        _assert_canaries_absent(capture_logs.text)
+        _assert_canaries_absent(_all_span_text(recording_tracer))
+
+    def test_canonical_span_shape_on_success(
+        self, client, monkeypatch, capture_logs, recording_tracer
+    ):
+        fake = FakeClientSession(result=FakeCallToolResult(False, "ok"))
+        _install_fake_session(monkeypatch, fake)
+
+        client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"query": "x"},
+        )
+
+        spans = [s for s in recording_tracer.spans if s.name == "tools/call test_tool"]
+        assert len(spans) == 1, "exactly one canonical operation span per request"
+        span = spans[0]
+        assert span.attributes["mcp.method.name"] == "tools/call"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+        assert span.attributes["gen_ai.tool.name"] == "test_tool"
+        assert span.attributes["enterprise_mcp_bridge.transport"] == "rest"
+        assert span.attributes["user.id"] == "user-42"
+        assert span.attributes["enterprise_mcp_bridge.auth.mode"] == "keycloak"
+        assert span.attributes["enterprise_mcp_bridge.request.id"]
+        assert span.attributes["enterprise_mcp_bridge.argument.keys"] == ["query"]
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"
+        assert span.attributes["enterprise_mcp_bridge.result.item_count"] == 1
+        assert span.attributes["enterprise_mcp_bridge.result.encoded_bytes"] > 0
+
+    def test_downstream_error_result_is_classified_not_leaked(
+        self, client, monkeypatch, capture_logs, recording_tracer
+    ):
+        fake = FakeClientSession(
+            result=FakeCallToolResult(True, f"Execution failed: {CANARY_SECRET}")
+        )
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"query": "x"},
+        )
+
+        assert response.status_code == 422  # API contract: terminal tool error
+        _assert_canaries_absent(capture_logs.text)
+        span_text = _all_span_text(recording_tracer)
+        _assert_canaries_absent(span_text)
+        span = next(
+            s for s in recording_tracer.spans if s.name == "tools/call test_tool"
+        )
+        assert span.attributes["error.type"] == "downstream_execution_error"
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "error"
+        assert span.status is not None
+
+    def test_downstream_exception_is_sanitized(
+        self, client, monkeypatch, capture_logs, recording_tracer
+    ):
+        fake = FakeClientSession(
+            call_error=RuntimeError(f"exploded with {CANARY_SECRET} and {CANARY_EMAIL}")
+        )
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"query": "x"},
+        )
+
+        assert response.status_code == 500
+        _assert_canaries_absent(capture_logs.text)
+        span_text = _all_span_text(recording_tracer)
+        _assert_canaries_absent(span_text)
+        span = next(
+            s for s in recording_tracer.spans if s.name == "tools/call test_tool"
+        )
+        assert span.attributes["error.type"] == "bridge_internal_error"
+        assert span.events and span.events[0][1]["exception.type"] == "RuntimeError"
+
+
+class TestRestPromptCanary:
+    def test_prompt_args_never_logged(
+        self, client, monkeypatch, capture_logs, recording_tracer
+    ):
+        class FakePromptResult:
+            description = "desc"
+            messages = []
+            meta = None
+
+        class FakePromptSession(FakeClientSession):
+            async def get_prompt(self, name, arguments=None):
+                return FakePromptResult()
+
+        _install_fake_session(monkeypatch, FakePromptSession())
+
+        response = client.post(
+            "/prompts/test_prompt",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"topic": CANARY_SECRET},
+        )
+
+        assert response.status_code == 200
+        _assert_canaries_absent(capture_logs.text)
+        _assert_canaries_absent(_all_span_text(recording_tracer))
+        span = next(
+            s for s in recording_tracer.spans if s.name == "prompts/get test_prompt"
+        )
+        assert span.attributes["mcp.method.name"] == "prompts/get"
+        assert span.attributes["enterprise_mcp_bridge.argument.keys"] == ["topic"]
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"
+
+
+class TestRestPromptErrorMapping:
+    def test_prompt_error_maps_through_description_not_attributeerror(
+        self, client, monkeypatch, recording_tracer
+    ):
+        """RunPromptResult has no `content`; the error mapping must read
+        `description` instead of raising AttributeError and collapsing every
+        prompt failure into a generic 500."""
+
+        class BadMessage:
+            role = "assistant"
+
+            @property
+            def content(self):
+                raise RuntimeError("Unknown prompt: nope")
+
+        class BrokenPromptResult:
+            description = "desc"
+            meta = None
+            # Consuming messages raises inside RunPromptResult.__init__, which
+            # records the failure text in `description` with isError=True.
+            messages = [BadMessage()]
+
+        class FakePromptSession(FakeClientSession):
+            async def get_prompt(self, name, arguments=None):
+                return BrokenPromptResult()
+
+        _install_fake_session(monkeypatch, FakePromptSession())
+
+        response = client.post(
+            "/prompts/test_prompt",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={},
+        )
+
+        # The "Unknown prompt" text in `description` maps to 404 — before the
+        # fix this was an AttributeError collapsing into a generic 500.
+        assert response.status_code == 404
+        assert "Unknown prompt" in response.text
+
+
+class TestDownstreamLogNotificationCanary:
+    @pytest.mark.asyncio
+    async def test_notification_payload_is_not_logged(self, capture_logs):
+        from app.session.client_strategy import _log_mcp_notification
+
+        class FakeParams:
+            level = "error"
+            logger = "downstream"
+            data = {"secret": CANARY_SECRET, "email": CANARY_EMAIL}
+
+        await _log_mcp_notification(FakeParams())
+
+        assert CANARY_SECRET not in capture_logs.text
+        assert CANARY_EMAIL not in capture_logs.text
+        # The notification itself is still visible as metadata.
+        assert "[MCP][downstream][ERROR]" in capture_logs.text
+
+
+class TestToolPolicyFailClosed:
+    @pytest.fixture
+    def pilot_allowlist(self, monkeypatch):
+        monkeypatch.setattr(session_context, "INCLUDE_TOOLS", ["test_tool"])
+        monkeypatch.setattr(session_context, "EXCLUDE_TOOLS", [])
+
+    def test_direct_call_to_hidden_tool_is_rejected_before_downstream(
+        self, client, monkeypatch, pilot_allowlist, recording_tracer
+    ):
+        fake = FakeClientSession(result=FakeCallToolResult(False, "should not run"))
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/hidden_tool",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={"query": "x"},
+        )
+
+        assert response.status_code == 404
+        assert fake.calls == [], "downstream must never be contacted"
+
+    def test_unknown_tool_is_rejected_before_downstream(
+        self, client, monkeypatch, pilot_allowlist
+    ):
+        fake = FakeClientSession(result=FakeCallToolResult(False, "should not run"))
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/get_span_details",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={},
+        )
+
+        assert response.status_code == 404
+        assert fake.calls == []
+
+    def test_allowed_tool_still_runs(self, client, monkeypatch, pilot_allowlist):
+        fake = FakeClientSession(result=FakeCallToolResult(False, "ok"))
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool", headers={TOKEN_HEADER: ACCESS_TOKEN}, json={}
+        )
+
+        assert response.status_code == 200
+        assert len(fake.calls) == 1
+
+    def test_streaming_route_rejects_hidden_tool_before_downstream(
+        self, client, monkeypatch, pilot_allowlist
+    ):
+        fake = FakeClientSession(result=FakeCallToolResult(False, "should not run"))
+        _install_fake_session(monkeypatch, fake)
+
+        with client.stream(
+            "POST",
+            "/tools/hidden_tool/stream",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={},
+        ) as response:
+            body = "".join(chunk for chunk in response.iter_text())
+
+        assert "error" in body
+        assert fake.calls == []
+
+
+class TestResponseByteCeiling:
+    def test_oversized_response_is_rejected_not_relayed(
+        self, client, monkeypatch, recording_tracer
+    ):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 64)
+        fake = FakeClientSession(
+            result=FakeCallToolResult(False, "x" * 500 + CANARY_SECRET)
+        )
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool", headers={TOKEN_HEADER: ACCESS_TOKEN}, json={}
+        )
+
+        assert response.status_code == 422
+        assert CANARY_SECRET not in response.text
+        assert "ceiling" in response.text
+
+    def test_within_ceiling_passes(self, client, monkeypatch):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 10_000)
+        fake = FakeClientSession(result=FakeCallToolResult(False, "small"))
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool", headers={TOKEN_HEADER: ACCESS_TOKEN}, json={}
+        )
+
+        assert response.status_code == 200
+
+
+class TestResponseByteCeilingPromptsAndResources:
+    """The ceiling applies to every instrumented MCP request type, not only
+    tools/call."""
+
+    def test_oversized_prompt_is_rejected(self, client, monkeypatch):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 64)
+
+        class BigMessageContent:
+            type = "text"
+            text = "y" * 5000
+
+        class BigMessage:
+            role = "assistant"
+            content = BigMessageContent()
+
+        class FakePromptResult:
+            description = "desc"
+            messages = [BigMessage()]
+            meta = None
+
+        class FakePromptSession(FakeClientSession):
+            async def get_prompt(self, name, arguments=None):
+                return FakePromptResult()
+
+        _install_fake_session(monkeypatch, FakePromptSession())
+
+        response = client.post(
+            "/prompts/test_prompt",
+            headers={TOKEN_HEADER: ACCESS_TOKEN},
+            json={},
+        )
+
+        assert response.status_code == 422
+        assert "y" * 100 not in response.text
+        assert "ceiling" in response.text
+
+    def test_oversized_resource_read_is_rejected(self, client, monkeypatch):
+        from app import vars as app_vars
+
+        monkeypatch.setattr(app_vars, "MCP_MAX_RESPONSE_BYTES", 64)
+
+        class BigResourceContent:
+            mimeType = "text/plain"
+            text = "z" * 5000
+
+        class FakeResourceResult:
+            contents = [BigResourceContent()]
+
+            def model_dump_json(self):
+                import json
+
+                return json.dumps({"contents": [{"text": "z" * 5000}]})
+
+        class ResourceRef:
+            name = "big_resource"
+            uri = "file:///big_resource"
+
+        class ResourceList:
+            resources = [ResourceRef()]
+
+        class FakeResourceSession(FakeClientSession):
+            async def list_resources(self):
+                return ResourceList()
+
+            async def read_resource(self, uri):
+                return FakeResourceResult()
+
+        _install_fake_session(monkeypatch, FakeResourceSession())
+
+        response = client.get(
+            "/resources/big_resource", headers={TOKEN_HEADER: ACCESS_TOKEN}
+        )
+
+        assert response.status_code == 422
+        assert "z" * 100 not in response.text
+        assert "ceiling" in response.text
+
+
+class TestTraceContextPropagation:
+    def test_trace_context_reaches_fake_downstream_in_meta(
+        self, client, monkeypatch, recording_tracer
+    ):
+        def fake_inject(carrier):
+            carrier["traceparent"] = "00-feedface-cafebabe-01"
+
+        monkeypatch.setattr(mcp_operation, "inject", fake_inject)
+        monkeypatch.setattr(mcp_operation, "MCP_TRACE_BAGGAGE_ALLOWLIST", ["tenant.id"])
+        monkeypatch.setattr(
+            mcp_operation.baggage,
+            "get_all",
+            lambda: {"tenant.id": "tenant-1", "not.allowlisted": CANARY_SECRET},
+        )
+
+        fake = FakeClientSession(result=FakeCallToolResult(False, "ok"))
+        _install_fake_session(monkeypatch, fake)
+
+        response = client.post(
+            "/tools/test_tool", headers={TOKEN_HEADER: ACCESS_TOKEN}, json={}
+        )
+
+        assert response.status_code == 200
+        meta = fake.calls[0]["meta"]
+        assert meta["traceparent"] == "00-feedface-cafebabe-01"
+        assert meta["baggage"] == "tenant.id=tenant-1"
+        assert CANARY_SECRET not in str(meta)

--- a/app/utils/mcp_operation.py
+++ b/app/utils/mcp_operation.py
@@ -1,0 +1,408 @@
+"""Shared wide-event telemetry for MCP operations.
+
+Every handled ``tools/call``, ``resources/read`` and ``prompts/get`` request —
+whether it arrives over the MCP SSE proxy or the REST compatibility routes —
+must be routed through :func:`mcp_operation_span` so all transports emit the
+same single canonical operation span and cannot drift.
+
+Sensitive-content policy (unconditional): raw tool/prompt arguments, results,
+resource bodies, credentials and untrusted exception messages never enter
+span attributes, span events or log lines produced by this module. Only safe
+metadata is recorded: argument key names/count, result item count, encoded
+size, truncation state, bounded error classifications and exception type
+names.
+"""
+
+import json
+import logging
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+import jwt
+from opentelemetry import baggage, trace
+from opentelemetry.propagate import inject
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from app.utils import token_fingerprint
+from app.vars import (
+    AUTH_PROVIDER,
+    MCP_REMOTE_SERVER,
+    MCP_TRACE_BAGGAGE_ALLOWLIST,
+)
+
+logger = logging.getLogger("uvicorn.error")
+
+_tracer = trace.get_tracer("app.utils.mcp_operation")
+
+# Canonical MCP JSON-RPC method names covered by the wide-event seam.
+MCP_METHOD_TOOLS_CALL = "tools/call"
+MCP_METHOD_RESOURCES_READ = "resources/read"
+MCP_METHOD_PROMPTS_GET = "prompts/get"
+
+# gen_ai.operation.name values per method (OTel GenAI semantic conventions).
+_GEN_AI_OPERATION_BY_METHOD = {
+    MCP_METHOD_TOOLS_CALL: "execute_tool",
+}
+
+# Bounded error classification values for `error.type`. Free-text error
+# messages are untrusted and must never widen this set.
+ERROR_TYPE_VALIDATION = "validation_error"
+ERROR_TYPE_AUTHORIZATION = "authorization_error"
+ERROR_TYPE_UPSTREAM_TIMEOUT = "upstream_timeout"
+ERROR_TYPE_DOWNSTREAM_EXECUTION = "downstream_execution_error"
+ERROR_TYPE_RESPONSE_TOO_LARGE = "response_too_large"
+ERROR_TYPE_BRIDGE_INTERNAL = "bridge_internal_error"
+
+RESULT_STATUS_SUCCESS = "success"
+RESULT_STATUS_ERROR = "error"
+
+# Transport values for `enterprise_mcp_bridge.transport`.
+TRANSPORT_REST = "rest"
+TRANSPORT_SSE = "sse"
+
+_HTTP_STATUS_TO_ERROR_TYPE = {
+    401: ERROR_TYPE_AUTHORIZATION,
+    403: ERROR_TYPE_AUTHORIZATION,
+    504: ERROR_TYPE_UPSTREAM_TIMEOUT,
+}
+
+
+def safe_arg_keys(args: Optional[Dict]) -> list[str]:
+    """Argument key names only — values are sensitive and never collected."""
+    if not isinstance(args, dict):
+        return []
+    return sorted(str(k) for k in args.keys())
+
+
+def extract_opaque_user_id(access_token: Optional[str]) -> Optional[str]:
+    """Return the token's `sub` claim — an opaque stable ID — or None.
+
+    Deliberately no fallback to preferred_username/email: those are PII and
+    must never become the telemetry user id.
+    """
+    if not access_token:
+        return None
+    try:
+        payload = jwt.decode(access_token, options={"verify_signature": False})
+    except Exception:
+        return None
+    sub = payload.get("sub")
+    return str(sub) if sub else None
+
+
+def downstream_server_label() -> Optional[str]:
+    """Bounded name of the configured downstream MCP server.
+
+    Only hostname (and port) — never netloc or the raw URL, both of which can
+    embed user:password@ credentials.
+    """
+    import os
+    from urllib.parse import urlparse
+
+    remote = (MCP_REMOTE_SERVER or "").strip()
+    if remote:
+        try:
+            parsed = urlparse(remote)
+            hostname = parsed.hostname
+            port = parsed.port
+        except ValueError:
+            return None
+        if not hostname:
+            return None
+        return f"{hostname}:{port}" if port else hostname
+    command = os.environ.get("MCP_SERVER_COMMAND", "").strip()
+    if command:
+        return command.split()[0].rsplit("/", 1)[-1]
+    return None
+
+
+def classify_error_text(error_text: str) -> str:
+    """Map a downstream isError result to a bounded error type.
+
+    FastMCP flattens exception classes to prose, so the text is all we have
+    to classify on. The text itself is untrusted and is not recorded.
+    """
+    lowered = (error_text or "").lower()
+    if "unknown tool" in lowered or "unknown prompt" in lowered:
+        return ERROR_TYPE_VALIDATION
+    if "validation error" in lowered:
+        return ERROR_TYPE_VALIDATION
+    if "timed out" in lowered:
+        return ERROR_TYPE_UPSTREAM_TIMEOUT
+    return ERROR_TYPE_DOWNSTREAM_EXECUTION
+
+
+def classify_exception(exc: BaseException) -> str:
+    """Map an exception to a bounded error type without trusting its message."""
+    from fastapi import HTTPException
+
+    if isinstance(exc, HTTPException):
+        status = exc.status_code
+        mapped = _HTTP_STATUS_TO_ERROR_TYPE.get(status)
+        if mapped:
+            return mapped
+        if 400 <= status < 500:
+            return ERROR_TYPE_VALIDATION
+        return ERROR_TYPE_BRIDGE_INTERNAL
+
+    try:
+        from app.oauth.token_exchange import UserLoggedOutException
+
+        if isinstance(exc, UserLoggedOutException):
+            return ERROR_TYPE_AUTHORIZATION
+    except Exception:  # pragma: no cover - import safety only
+        pass
+
+    # Imported lazily: session_context imports this module at load time.
+    try:
+        from app.session_manager.session_context import (
+            ResponseTooLargeError,
+            ToolPolicyDeniedError,
+        )
+
+        if isinstance(exc, ToolPolicyDeniedError):
+            return ERROR_TYPE_AUTHORIZATION
+        if isinstance(exc, ResponseTooLargeError):
+            return ERROR_TYPE_RESPONSE_TOO_LARGE
+    except Exception:  # pragma: no cover - import safety only
+        pass
+
+    if isinstance(exc, PermissionError):
+        return ERROR_TYPE_AUTHORIZATION
+    if isinstance(exc, TimeoutError):
+        return ERROR_TYPE_UPSTREAM_TIMEOUT
+    exc_name = type(exc).__name__
+    if exc_name == "McpError" and "timed out" in str(exc).lower():
+        return ERROR_TYPE_UPSTREAM_TIMEOUT
+    return ERROR_TYPE_BRIDGE_INTERNAL
+
+
+def log_sanitized_exception(
+    log: logging.Logger, prefix: str, exc: BaseException
+) -> None:
+    """Log an exception without its message.
+
+    Downstream exception messages can embed request/response content, so on
+    MCP request paths only the exception type and bounded classification are
+    logged; the full traceback stays out of application logs.
+    """
+    log.error(
+        "%s Exception: type=%s error.type=%s",
+        prefix,
+        type(exc).__name__,
+        classify_exception(exc),
+    )
+
+
+def encoded_result_size(result: Any) -> Optional[int]:
+    """Byte size of the JSON-encoded result; None when it cannot be encoded."""
+    try:
+        if hasattr(result, "model_dump_json"):
+            return len(result.model_dump_json().encode("utf-8"))
+        return len(json.dumps(result, default=str).encode("utf-8"))
+    except Exception:
+        return None
+
+
+def result_item_count(result: Any) -> Optional[int]:
+    content = getattr(result, "content", None)
+    if isinstance(content, list):
+        return len(content)
+    messages = getattr(result, "messages", None)
+    if isinstance(messages, list):
+        return len(messages)
+    contents = getattr(result, "contents", None)
+    if isinstance(contents, list):
+        return len(contents)
+    return None
+
+
+def downstream_call_kwargs(
+    call_fn: Any, *, trace_meta: Optional[Dict[str, str]] = None
+) -> Dict[str, Any]:
+    """Optional kwargs (trace meta, timeout) the downstream call supports.
+
+    Trace context travels in the MCP ``_meta`` field: only ``traceparent``,
+    ``tracestate`` and allowlisted baggage, never arbitrary headers. Pass
+    ``trace_meta`` explicitly when the call happens outside the request's
+    span context (e.g. in the persistent session task).
+    """
+    import inspect
+    from datetime import timedelta
+
+    from app import vars as app_vars
+
+    kwargs: Dict[str, Any] = {}
+    try:
+        params = inspect.signature(call_fn).parameters
+        has_var_kw = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+    except (TypeError, ValueError):
+        return kwargs
+    if "meta" in params or has_var_kw:
+        meta = trace_meta if trace_meta is not None else build_trace_meta()
+        if meta:
+            kwargs["meta"] = meta
+    if app_vars.MCP_TOOL_TIMEOUT_SECONDS > 0 and (
+        "read_timeout_seconds" in params or has_var_kw
+    ):
+        kwargs["read_timeout_seconds"] = timedelta(
+            seconds=app_vars.MCP_TOOL_TIMEOUT_SECONDS
+        )
+    return kwargs
+
+
+def build_trace_meta() -> Dict[str, str]:
+    """W3C trace context plus allowlisted baggage for the MCP ``_meta`` field.
+
+    Only ``traceparent``, ``tracestate`` and explicitly allowlisted baggage
+    keys are propagated; arbitrary baggage and wildcard headers never are.
+    """
+    carrier: Dict[str, str] = {}
+    inject(carrier)
+    meta = {
+        key: value
+        for key, value in carrier.items()
+        if key in ("traceparent", "tracestate")
+    }
+    allowed_baggage = {
+        key: str(value)
+        for key, value in baggage.get_all().items()
+        if key in MCP_TRACE_BAGGAGE_ALLOWLIST
+    }
+    if allowed_baggage:
+        meta["baggage"] = ",".join(
+            f"{key}={value}" for key, value in sorted(allowed_baggage.items())
+        )
+    return meta
+
+
+@dataclass
+class MCPOperationRecorder:
+    """Handle for the canonical span; records only safe result metadata."""
+
+    span: trace.Span
+    _finalized: bool = field(default=False, init=False)
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        if value is not None:
+            self.span.set_attribute(key, value)
+
+    def record_success(self, result: Any = None, truncated: bool = False) -> None:
+        self._finalized = True
+        self.set_attribute("enterprise_mcp_bridge.result.status", RESULT_STATUS_SUCCESS)
+        self.set_attribute("enterprise_mcp_bridge.result.truncated", truncated)
+        if result is None:
+            return
+        self.set_attribute(
+            "enterprise_mcp_bridge.result.item_count", result_item_count(result)
+        )
+        self.set_attribute(
+            "enterprise_mcp_bridge.result.encoded_bytes", encoded_result_size(result)
+        )
+
+    def record_error_result(
+        self, error_type: str, result: Any = None, truncated: bool = False
+    ) -> None:
+        """Record a downstream isError result (the request itself completed)."""
+        self._finalized = True
+        self.set_attribute("enterprise_mcp_bridge.result.status", RESULT_STATUS_ERROR)
+        self.set_attribute("error.type", error_type)
+        self.set_attribute("enterprise_mcp_bridge.result.truncated", truncated)
+        if result is not None:
+            self.set_attribute(
+                "enterprise_mcp_bridge.result.item_count", result_item_count(result)
+            )
+            self.set_attribute(
+                "enterprise_mcp_bridge.result.encoded_bytes",
+                encoded_result_size(result),
+            )
+        self.span.set_status(Status(StatusCode.ERROR))
+
+    def record_exception(self, exc: BaseException) -> None:
+        """Record a failure with a sanitized exception event.
+
+        Only the exception type name and the bounded classification are
+        attached; untrusted messages and stack data are omitted.
+        """
+        self._finalized = True
+        error_type = classify_exception(exc)
+        self.set_attribute("enterprise_mcp_bridge.result.status", RESULT_STATUS_ERROR)
+        self.set_attribute("error.type", error_type)
+        self.span.add_event(
+            "exception",
+            {
+                "exception.type": type(exc).__name__,
+                "error.type": error_type,
+            },
+        )
+        self.span.set_status(Status(StatusCode.ERROR))
+
+
+@contextmanager
+def mcp_operation_span(
+    *,
+    method: str,
+    target: Optional[str] = None,
+    transport: str,
+    session_value: Optional[str] = None,
+    access_token: Optional[str] = None,
+    group: Optional[str] = None,
+    arg_keys: Optional[Iterable[str]] = None,
+    request_id: Optional[str] = None,
+    protocol_version: Optional[str] = None,
+    client_name: Optional[str] = None,
+    client_version: Optional[str] = None,
+):
+    """Emit the single canonical wide operation span for one MCP request.
+
+    Missing context is omitted, never fabricated. The session attribute is a
+    fingerprint because bridge session values can embed the caller's access
+    token. Exceptions are classified, sanitized and re-raised.
+    """
+    span_name = f"{method} {target}" if target else method
+    with _tracer.start_as_current_span(span_name, kind=SpanKind.SERVER) as span:
+        recorder = MCPOperationRecorder(span)
+        recorder.set_attribute("mcp.method.name", method)
+        gen_ai_operation = _GEN_AI_OPERATION_BY_METHOD.get(method)
+        recorder.set_attribute("gen_ai.operation.name", gen_ai_operation)
+        if method == MCP_METHOD_TOOLS_CALL and target:
+            recorder.set_attribute("gen_ai.tool.name", target)
+        elif target:
+            recorder.set_attribute("enterprise_mcp_bridge.target.name", target)
+        recorder.set_attribute("enterprise_mcp_bridge.transport", transport)
+        if session_value:
+            recorder.set_attribute("mcp.session.id", token_fingerprint(session_value))
+        recorder.set_attribute(
+            "enterprise_mcp_bridge.request.id", request_id or str(uuid.uuid4())
+        )
+        recorder.set_attribute("mcp.protocol.version", protocol_version)
+        recorder.set_attribute("enterprise_mcp_bridge.client.name", client_name)
+        recorder.set_attribute("enterprise_mcp_bridge.client.version", client_version)
+        recorder.set_attribute(
+            "enterprise_mcp_bridge.downstream.server", downstream_server_label()
+        )
+        recorder.set_attribute("user.id", extract_opaque_user_id(access_token))
+        recorder.set_attribute("enterprise_mcp_bridge.group.id", group)
+        recorder.set_attribute(
+            "enterprise_mcp_bridge.auth.mode",
+            AUTH_PROVIDER if access_token else "anonymous",
+        )
+        if arg_keys is not None:
+            keys = list(arg_keys)
+            recorder.set_attribute("enterprise_mcp_bridge.argument.keys", keys)
+            recorder.set_attribute("enterprise_mcp_bridge.argument.count", len(keys))
+        try:
+            yield recorder
+        except BaseException as exc:
+            # An already-recorded downstream classification (e.g. an isError
+            # result re-raised as an HTTP status) wins over the raise itself.
+            if not recorder._finalized:
+                recorder.record_exception(exc)
+            raise
+        else:
+            if not recorder._finalized:
+                recorder.record_success()

--- a/app/utils/test_mcp_operation.py
+++ b/app/utils/test_mcp_operation.py
@@ -1,0 +1,301 @@
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from app.session_manager.session_context import (
+    ResponseTooLargeError,
+    ToolPolicyDeniedError,
+)
+from app.utils import mcp_operation
+from app.utils.mcp_operation import (
+    ERROR_TYPE_AUTHORIZATION,
+    ERROR_TYPE_BRIDGE_INTERNAL,
+    ERROR_TYPE_DOWNSTREAM_EXECUTION,
+    ERROR_TYPE_RESPONSE_TOO_LARGE,
+    ERROR_TYPE_UPSTREAM_TIMEOUT,
+    ERROR_TYPE_VALIDATION,
+    build_trace_meta,
+    classify_error_text,
+    classify_exception,
+    downstream_call_kwargs,
+    extract_opaque_user_id,
+    mcp_operation_span,
+    safe_arg_keys,
+)
+from app.utils_tests.recording_tracer import RecordingTracer, span_payload_text
+
+CANARY = "canary-secret-XYZZY-9f8e7d"
+
+
+@pytest.fixture
+def recording_tracer(monkeypatch):
+    tracer = RecordingTracer()
+    monkeypatch.setattr(mcp_operation, "_tracer", tracer)
+    return tracer
+
+
+class TestClassification:
+    def test_error_text_unknown_tool_is_validation(self):
+        assert classify_error_text("Unknown tool: nope") == ERROR_TYPE_VALIDATION
+
+    def test_error_text_validation_error(self):
+        assert classify_error_text("1 validation error for x") == ERROR_TYPE_VALIDATION
+
+    def test_error_text_timeout(self):
+        assert (
+            classify_error_text("Request timed out after 60 seconds.")
+            == ERROR_TYPE_UPSTREAM_TIMEOUT
+        )
+
+    def test_error_text_default_is_downstream_execution(self):
+        assert classify_error_text("boom") == ERROR_TYPE_DOWNSTREAM_EXECUTION
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (400, ERROR_TYPE_VALIDATION),
+            (401, ERROR_TYPE_AUTHORIZATION),
+            (403, ERROR_TYPE_AUTHORIZATION),
+            (404, ERROR_TYPE_VALIDATION),
+            (504, ERROR_TYPE_UPSTREAM_TIMEOUT),
+            (500, ERROR_TYPE_BRIDGE_INTERNAL),
+        ],
+    )
+    def test_http_exception_mapping(self, status, expected):
+        assert classify_exception(HTTPException(status_code=status)) == expected
+
+    def test_tool_policy_denied_is_authorization(self):
+        assert (
+            classify_exception(ToolPolicyDeniedError("hidden"))
+            == ERROR_TYPE_AUTHORIZATION
+        )
+
+    def test_response_too_large(self):
+        assert (
+            classify_exception(ResponseTooLargeError(10, 5))
+            == ERROR_TYPE_RESPONSE_TOO_LARGE
+        )
+
+    def test_timeout_error(self):
+        assert classify_exception(TimeoutError()) == ERROR_TYPE_UPSTREAM_TIMEOUT
+
+    def test_generic_exception_is_bridge_internal(self):
+        assert classify_exception(RuntimeError(CANARY)) == ERROR_TYPE_BRIDGE_INTERNAL
+
+
+class TestSafeMetadata:
+    def test_safe_arg_keys_returns_sorted_keys_only(self):
+        assert safe_arg_keys({"b": CANARY, "a": 1}) == ["a", "b"]
+
+    def test_safe_arg_keys_handles_non_dict(self):
+        assert safe_arg_keys(None) == []
+        assert safe_arg_keys("string") == []
+
+    def test_user_id_is_sub_claim_only(self):
+        token = jwt.encode(
+            {"sub": "user-42", "email": "alice@example.com"},
+            "secret",
+            algorithm="HS256",
+        )
+        assert extract_opaque_user_id(token) == "user-42"
+
+    def test_user_id_never_falls_back_to_email(self):
+        token = jwt.encode(
+            {"email": "alice@example.com", "preferred_username": "alice"},
+            "secret",
+            algorithm="HS256",
+        )
+        assert extract_opaque_user_id(token) is None
+
+    def test_user_id_of_garbage_token_is_none(self):
+        assert extract_opaque_user_id("not-a-jwt") is None
+        assert extract_opaque_user_id(None) is None
+
+
+class TestTraceMeta:
+    def test_default_allowlist_forwards_no_baggage(self, monkeypatch):
+        monkeypatch.setattr(
+            mcp_operation.baggage, "get_all", lambda: {"tenant.id": "tenant-1"}
+        )
+        monkeypatch.setattr(mcp_operation, "inject", lambda carrier: None)
+        assert "baggage" not in build_trace_meta()
+
+    def test_only_traceparent_tracestate_and_allowlisted_baggage(self, monkeypatch):
+        monkeypatch.setattr(mcp_operation, "MCP_TRACE_BAGGAGE_ALLOWLIST", ["tenant.id"])
+
+        def fake_inject(carrier):
+            carrier["traceparent"] = "00-abc-def-01"
+            carrier["tracestate"] = "vendor=1"
+            carrier["x-arbitrary-header"] = "nope"
+
+        monkeypatch.setattr(mcp_operation, "inject", fake_inject)
+        monkeypatch.setattr(
+            mcp_operation.baggage,
+            "get_all",
+            lambda: {
+                "tenant.id": "tenant-1",
+                "session.token": CANARY,
+                "user.email": "alice@example.com",
+            },
+        )
+
+        meta = build_trace_meta()
+
+        assert meta["traceparent"] == "00-abc-def-01"
+        assert meta["tracestate"] == "vendor=1"
+        assert "x-arbitrary-header" not in meta
+        assert meta["baggage"] == "tenant.id=tenant-1"
+        assert CANARY not in str(meta)
+
+    def test_downstream_call_kwargs_passes_meta_when_supported(self, monkeypatch):
+        async def call_with_meta(name, args, *, meta=None, read_timeout_seconds=None):
+            return None
+
+        monkeypatch.setattr(
+            mcp_operation, "build_trace_meta", lambda: {"traceparent": "00-abc"}
+        )
+        kwargs = downstream_call_kwargs(call_with_meta)
+        assert kwargs["meta"] == {"traceparent": "00-abc"}
+
+    def test_downstream_call_kwargs_skips_meta_when_unsupported(self):
+        async def plain_call(name, args):
+            return None
+
+        assert downstream_call_kwargs(plain_call) == {}
+
+    def test_downstream_call_kwargs_applies_timeout(self, monkeypatch):
+        from app import vars as app_vars
+
+        async def call_with_timeout(
+            name, args, *, meta=None, read_timeout_seconds=None
+        ):
+            return None
+
+        monkeypatch.setattr(app_vars, "MCP_TOOL_TIMEOUT_SECONDS", 7.0)
+        kwargs = downstream_call_kwargs(
+            call_with_timeout, trace_meta={"traceparent": "00-abc"}
+        )
+        assert kwargs["read_timeout_seconds"].total_seconds() == 7.0
+        assert kwargs["meta"] == {"traceparent": "00-abc"}
+
+
+class TestDownstreamServerLabel:
+    def test_remote_url_credentials_never_recorded(self, monkeypatch):
+        from app.utils.mcp_operation import downstream_server_label
+
+        monkeypatch.setattr(
+            mcp_operation,
+            "MCP_REMOTE_SERVER",
+            f"http://user:{CANARY}@mcp.internal:16686/api/mcp/",
+        )
+        label = downstream_server_label()
+        assert label == "mcp.internal:16686"
+        assert CANARY not in label
+
+    def test_remote_url_without_port(self, monkeypatch):
+        from app.utils.mcp_operation import downstream_server_label
+
+        monkeypatch.setattr(
+            mcp_operation, "MCP_REMOTE_SERVER", "https://mcp.internal/mcp"
+        )
+        assert downstream_server_label() == "mcp.internal"
+
+    def test_unparseable_remote_is_omitted(self, monkeypatch):
+        from app.utils.mcp_operation import downstream_server_label
+
+        monkeypatch.setattr(
+            mcp_operation, "MCP_REMOTE_SERVER", f"user:{CANARY}@nowhere"
+        )
+        label = downstream_server_label()
+        assert label is None or CANARY not in str(label)
+
+
+class _FakeResult:
+    def __init__(self, is_error=False, texts=("ok",)):
+        self.isError = is_error
+        self.content = [type("C", (), {"text": t})() for t in texts]
+
+
+class TestOperationSpan:
+    def test_success_records_wide_attributes(self, recording_tracer):
+        token = jwt.encode({"sub": "user-42"}, "secret", algorithm="HS256")
+        with mcp_operation_span(
+            method="tools/call",
+            target="get_services",
+            transport="rest",
+            session_value=f"session-1:{token}",
+            access_token=token,
+            group="observability",
+            arg_keys=["a", "b"],
+        ) as op:
+            op.record_success(_FakeResult())
+
+        (span,) = recording_tracer.spans
+        assert span.name == "tools/call get_services"
+        assert span.attributes["mcp.method.name"] == "tools/call"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+        assert span.attributes["gen_ai.tool.name"] == "get_services"
+        assert span.attributes["enterprise_mcp_bridge.transport"] == "rest"
+        assert span.attributes["user.id"] == "user-42"
+        assert span.attributes["enterprise_mcp_bridge.group.id"] == "observability"
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"
+        assert span.attributes["enterprise_mcp_bridge.result.item_count"] == 1
+        assert span.attributes["enterprise_mcp_bridge.result.truncated"] is False
+        assert span.attributes["enterprise_mcp_bridge.argument.count"] == 2
+        assert span.attributes["enterprise_mcp_bridge.request.id"]
+        # The session attribute is a fingerprint, never the raw value.
+        assert token not in str(span.attributes["mcp.session.id"])
+
+    def test_error_result_sets_status_and_bounded_type(self, recording_tracer):
+        with mcp_operation_span(
+            method="tools/call", target="t", transport="rest"
+        ) as op:
+            op.record_error_result(
+                ERROR_TYPE_DOWNSTREAM_EXECUTION, _FakeResult(is_error=True)
+            )
+
+        (span,) = recording_tracer.spans
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "error"
+        assert span.attributes["error.type"] == ERROR_TYPE_DOWNSTREAM_EXECUTION
+        assert span.status is not None
+
+    def test_exception_is_sanitized_and_reraised(self, recording_tracer):
+        with pytest.raises(RuntimeError):
+            with mcp_operation_span(method="tools/call", target="t", transport="rest"):
+                raise RuntimeError(f"downstream blew up: {CANARY}")
+
+        (span,) = recording_tracer.spans
+        assert span.attributes["error.type"] == ERROR_TYPE_BRIDGE_INTERNAL
+        assert span.status is not None
+        event_name, event_attrs = span.events[0]
+        assert event_name == "exception"
+        assert event_attrs["exception.type"] == "RuntimeError"
+        # The untrusted exception message never enters the span.
+        assert CANARY not in span_payload_text(span)
+
+    def test_exception_after_recorded_result_keeps_first_classification(
+        self, recording_tracer
+    ):
+        with pytest.raises(HTTPException):
+            with mcp_operation_span(
+                method="tools/call", target="t", transport="rest"
+            ) as op:
+                op.record_error_result(
+                    ERROR_TYPE_UPSTREAM_TIMEOUT, _FakeResult(is_error=True)
+                )
+                raise HTTPException(status_code=504, detail="timed out")
+
+        (span,) = recording_tracer.spans
+        assert span.attributes["error.type"] == ERROR_TYPE_UPSTREAM_TIMEOUT
+        assert not span.events  # no second, exception-based classification
+
+    def test_missing_context_is_omitted_not_fabricated(self, recording_tracer):
+        with mcp_operation_span(method="prompts/get", transport="sse"):
+            pass
+
+        (span,) = recording_tracer.spans
+        assert "user.id" not in span.attributes
+        assert "enterprise_mcp_bridge.group.id" not in span.attributes
+        assert "mcp.protocol.version" not in span.attributes
+        assert "gen_ai.tool.name" not in span.attributes
+        assert span.attributes["enterprise_mcp_bridge.result.status"] == "success"

--- a/app/utils/traced_requests.py
+++ b/app/utils/traced_requests.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from opentelemetry.trace import Tracer
 
-from app.utils import mask_token
+from app.utils import mask_token, token_fingerprint
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -22,7 +22,10 @@ def traced_request(
     """Context manager to create a span, set common attributes, and log a start message."""
     with tracer.start_as_current_span(operation) as span:
         if session_value:
-            span.set_attribute("session.id", session_value)
+            # Bridge session values embed the caller's access token
+            # (session_id() concatenates it), so only a fingerprint may
+            # become a span attribute.
+            span.set_attribute("session.id", token_fingerprint(session_value))
         if group:
             span.set_attribute("session.group", group)
         if user_id:

--- a/app/utils_tests/recording_tracer.py
+++ b/app/utils_tests/recording_tracer.py
@@ -1,0 +1,49 @@
+"""In-memory tracer double for asserting span content in tests.
+
+Works identically whether the real OpenTelemetry API or the repo-root test
+stub is on the path — tests patch ``app.utils.mcp_operation._tracer`` with an
+instance and assert on the recorded spans.
+"""
+
+from contextlib import contextmanager
+from typing import Any
+
+
+class RecordingSpan:
+    def __init__(self, name: str):
+        self.name = name
+        self.attributes: dict[str, Any] = {}
+        self.events: list[tuple[str, dict]] = []
+        self.status: Any = None
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: dict | None = None) -> None:
+        self.events.append((name, dict(attributes or {})))
+
+    def set_status(self, status: Any, description: str | None = None) -> None:
+        self.status = status
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **_kwargs: Any):
+        span = RecordingSpan(name)
+        self.spans.append(span)
+        yield span
+
+
+def span_payload_text(span: RecordingSpan) -> str:
+    """Every attribute and event value of a span, flattened for canary greps."""
+    parts = [span.name]
+    for key, value in span.attributes.items():
+        parts.append(f"{key}={value!r}")
+    for name, attributes in span.events:
+        parts.append(name)
+        for key, value in attributes.items():
+            parts.append(f"{key}={value!r}")
+    return "\n".join(parts)

--- a/app/vars.py
+++ b/app/vars.py
@@ -215,6 +215,44 @@ MCP_REMOTE_SERVER_FORWARD_HEADERS = [
     if h.strip()
 ]
 
+# Baggage keys the bridge may propagate to downstream MCP servers via _meta.
+# Empty (default) forwards no baggage at all: arbitrary baggage can carry
+# identity or request content and must never be forwarded wholesale.
+# Deployments opt keys in explicitly (e.g. "tenant.id,group.id").
+MCP_TRACE_BAGGAGE_ALLOWLIST = [
+    b.strip()
+    for b in os.getenv("MCP_TRACE_BAGGAGE_ALLOWLIST", "").split(",")
+    if b.strip()
+]
+
+# Groups a caller's token must carry (any of) to use this bridge instance at
+# all. Empty (default) disables the gate. Deployments whose downstream data
+# must stay restricted to an operator group set this so the bridge itself —
+# not only its ingress — enforces the authorization boundary: an
+# authenticated caller outside these groups gets 403 before any downstream
+# contact. Group membership is read from VERIFIED claims only (signature via
+# the realm JWKS, expiry, exact issuer, and the client allowlist below): the
+# bridge accepts direct Bearer tokens, so a forged unsigned token must never
+# pass this gate.
+BRIDGE_REQUIRED_GROUPS = [
+    g.strip() for g in os.getenv("BRIDGE_REQUIRED_GROUPS", "").split(",") if g.strip()
+]
+# Clients whose tokens the group gate accepts (matched against azp, falling
+# back to aud). REQUIRED whenever BRIDGE_REQUIRED_GROUPS is set — with no
+# allowlist the gate fails closed rather than trusting any client in the
+# realm (same idiom as USER_API_KEY_ALLOWED_CLIENTS).
+BRIDGE_ALLOWED_CLIENTS = [
+    c.strip() for c in os.getenv("BRIDGE_ALLOWED_CLIENTS", "").split(",") if c.strip()
+]
+
+# Ceiling on the JSON-encoded size of a downstream tool result. 0 disables
+# the check. Some downstream MCP servers enforce count-based limits, which do
+# not bound every serialized response, so the bridge has its own byte cap.
+MCP_MAX_RESPONSE_BYTES = int(os.getenv("MCP_MAX_RESPONSE_BYTES", "0"))
+
+# Per-call timeout towards the downstream MCP server. 0 keeps SDK defaults.
+MCP_TOOL_TIMEOUT_SECONDS = float(os.getenv("MCP_TOOL_TIMEOUT_SECONDS", "0"))
+
 
 def _parse_map_header_to_input(raw: str) -> dict:
     mapping: dict = {}

--- a/opentelemetry/__init__.py
+++ b/opentelemetry/__init__.py
@@ -1,5 +1,5 @@
 """Minimal stub of the opentelemetry package for testing."""
 
-from . import trace  # noqa: F401
+from . import baggage, trace  # noqa: F401
 
-__all__ = ["trace"]
+__all__ = ["baggage", "trace"]

--- a/opentelemetry/baggage/__init__.py
+++ b/opentelemetry/baggage/__init__.py
@@ -1,0 +1,10 @@
+"""Minimal baggage API stub used for unit testing."""
+
+from typing import Any, Mapping
+
+
+def get_all(context: Any = None) -> Mapping[str, object]:
+    return {}
+
+
+__all__ = ["get_all"]

--- a/opentelemetry/propagate.py
+++ b/opentelemetry/propagate.py
@@ -1,0 +1,11 @@
+"""Minimal propagate API stub used for unit testing."""
+
+from typing import Any, MutableMapping
+
+
+def inject(carrier: MutableMapping[str, str], context: Any = None) -> None:
+    """No-op: the stub has no active span context to propagate."""
+    return None
+
+
+__all__ = ["inject"]

--- a/opentelemetry/trace/__init__.py
+++ b/opentelemetry/trace/__init__.py
@@ -10,6 +10,8 @@ class _Span:
     def __init__(self, name: str = "") -> None:
         self.name = name
         self.attributes: dict[str, Any] = {}
+        self.events: list[tuple[str, dict]] = []
+        self.status: Any = None
 
     def __enter__(self) -> "_Span":
         return self
@@ -27,9 +29,18 @@ class _Span:
     def record_exception(self, _exception: Exception) -> None:
         return None
 
+    def add_event(self, name: str, attributes: dict | None = None) -> None:
+        self.events.append((name, dict(attributes or {})))
+
+    def set_status(self, status: Any, description: str | None = None) -> None:
+        self.status = status
+
+    def is_recording(self) -> bool:
+        return False
+
 
 class _SpanContextManager:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, **_kwargs: Any) -> None:
         self._span = _Span(name)
 
     def __enter__(self) -> _Span:
@@ -42,8 +53,8 @@ class _SpanContextManager:
 class Tracer:
     """Tracer stub exposing minimal tracing surface used in tests."""
 
-    def start_as_current_span(self, name: str) -> _SpanContextManager:
-        return _SpanContextManager(name)
+    def start_as_current_span(self, name: str, **kwargs: Any) -> _SpanContextManager:
+        return _SpanContextManager(name, **kwargs)
 
     def start_span(self, name: str) -> _Span:
         return _Span(name)
@@ -56,4 +67,42 @@ def get_tracer(_name: str) -> Tracer:
     return Tracer()
 
 
-__all__ = ["get_tracer", "Tracer", "Span"]
+class SpanKind:
+    """Span kind constants (stub)."""
+
+    INTERNAL = "internal"
+    SERVER = "server"
+    CLIENT = "client"
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+
+
+class StatusCode:
+    """Status code constants (stub)."""
+
+    UNSET = "unset"
+    OK = "ok"
+    ERROR = "error"
+
+
+class Status:
+    """Span status (stub)."""
+
+    def __init__(self, status_code: Any = None, description: str | None = None) -> None:
+        self.status_code = status_code
+        self.description = description
+
+
+def get_current_span() -> _Span:
+    return _Span()
+
+
+__all__ = [
+    "get_tracer",
+    "get_current_span",
+    "Tracer",
+    "Span",
+    "SpanKind",
+    "Status",
+    "StatusCode",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # lists and versions in sync when either changes.
 [project]
 name = "enterprise-mcp-bridge"
-version = "0.4.10"
+version = "0.4.11"
 description = "Wrapper for MCP Clients to be called via REST on a platform"
 license = "GPL-3.0"
 authors = [{ name = "Matthias Kainer", email = "matthias@inxm.ai" }]


### PR DESCRIPTION
Slice 1 of inxm-ai/ops-observe#84 — make `enterprise-mcp-bridge` the safe, observable policy boundary before any downstream MCP endpoint (first pilot: Jaeger's) becomes reachable by clients. **Single atomic commit** (`5fd54f2`); the earlier review rounds are preserved in this PR's timeline and resolved threads.

**Starting `origin/main` SHA:** `3afc6753c09a` · **Version bump included:** `0.4.10 → 0.4.11` in both pyprojects, so the merge is immediately taggable as the release downstream deployments pin.

## What this delivers

1. **One canonical wide span per MCP request** — shared seam `app/utils/mcp_operation.py`, routed through by both the MCP SSE proxy and the REST compatibility routes (incl. streaming), so transports cannot drift. Standard keys follow OTel semconv (`mcp.method.name`, `mcp.session.id`, `mcp.protocol.version`, `gen_ai.operation.name`, `gen_ai.tool.name`, `user.id` = JWT `sub` only, `error.type`); every custom attribute lives in the project-owned **`enterprise_mcp_bridge.*`** namespace (`transport`, `request.id`, `client.name/version`, `downstream.server`, `argument.keys/count`, `target.name`, `result.status/item_count/encoded_bytes/truncated`, `auth.mode`, `group.id`; resource `build.id`). Missing context is omitted, never fabricated.
2. **Sensitive content is never collected** — raw tool/prompt arguments, results, resource bodies, downstream logging-notification payloads and untrusted exception messages stay out of logs and spans; only key names/counts, item counts, sizes (computed without serializing untrusted payloads) and bounded classifications are recorded. Session values embed the caller's token → spans record fingerprints everywhere; the downstream server label is `hostname[:port]`, never netloc/raw URL (which can embed `user:password@`). API responses are unchanged — this changes telemetry, not the tool contract.
3. **Bounded failure classification** — OTel error status + sanitized exception event; `error.type` ∈ {validation, authorization, upstream_timeout, downstream_execution, response_too_large, bridge_internal}. Prompt failures map through `RunPromptResult.description` (the previous `content[0].text` access made the 404/400 branches unreachable — regression-tested).
4. **Trace context, allowlist-only** — `traceparent`/`tracestate` + explicitly allowlisted baggage injected into MCP `_meta`; `MCP_TRACE_BAGGAGE_ALLOWLIST` **defaults to empty** (forward nothing unless a deployment opts keys in).
5. **Fail-closed tool policy at execution time** — one shared `tool_allowed()` behind `tools/list` filtering AND every execution path; hidden/unknown tools are rejected before any downstream call; direct-call bypasses tested on both transports.
6. **Verified caller authorization** — `BRIDGE_REQUIRED_GROUPS` gates every request path (REST seam, session creation, SSE connect) using **verified claims only**: shared `verified_caller_claims()` enforces realm-JWKS signature, expiry, exact issuer, and the explicit `BRIDGE_ALLOWED_CLIENTS` allowlist (fail-closed when unset). The bridge accepts direct Bearer tokens, so a forged JWT claiming the right groups gets 401 before its group claims are read — tested against the real verifier. Default (both unset) keeps current behaviour.
7. **Response bounds** — named `MCP_MAX_RESPONSE_BYTES` ceiling (rejects, never truncates or partially relays) and `MCP_TOOL_TIMEOUT_SECONDS`, applied to tools/prompts/resources on all paths.
8. **Resource identity** — `service.version`, `service.instance.id`, `deployment.environment.name`, `enterprise_mcp_bridge.build.id` from env when present; `OTEL_RESOURCE_ATTRIBUTES` stays the source of truth.

## Verification

```
$ cd app && pytest        → 1533 passed, 14 skipped
$ pytest tests/           → 8 passed        (root conformance, pip install '.[testing]')
$ black --check <touched> → clean
$ cd "$TMPDIR" && python -c "import enterprise_mcp_bridge.testing, app.server"  → OK
```

Canary-secret suites plant synthetic credentials/PII in arguments, results, tokens, downstream exceptions and log notifications and assert them absent from captured logs and recorded spans, success and failure, on both transports. Trace-context tests assert the fake downstream received `traceparent` + allowlisted baggage only. Forged-token, bypass, oversized and timeout negatives included.

## Security boundary & rollback

The bridge is the authorization/redaction boundary: ingress oauth2-proxy authenticates, the bridge authorizes (verified groups + client allowlist), filters (execution-time allowlist), bounds (bytes/timeout) and redacts (wide spans, no raw content). Rollback: all new behaviour is env-gated (`BRIDGE_REQUIRED_GROUPS`/`BRIDGE_ALLOWED_CLIENTS`/`MCP_MAX_RESPONSE_BYTES`/`MCP_TOOL_TIMEOUT_SECONDS`/`MCP_TRACE_BAGGAGE_ALLOWLIST` unset = prior behaviour), except the telemetry sanitization and execution-time tool policy, which are unconditional by design.

## Devil's advocate (recorded per issue #84)

- **Bridge as boundary vs direct ingress**: oauth2-proxy can't authorize per-tool, redact, or cap; two mechanisms fail independently. Accepted.
- **`enterprise_mcp_bridge.*` vs more `mcp.*` keys**: the OTel MCP semconv namespace is evolving; squatting it invites collisions. Project-owned prefix is collision-proof. Accepted.
- **Ceiling rejects instead of truncating**: truncated JSON is broken or silently misleading for agent consumers; a clean error that says "narrow the query" is strictly better. `result.truncated` records every withholding. Accepted.
- **Sanitized exception events (no messages)**: costs operator debugging signal; the bounded class, exception type, latency and correlation remain, and the API response still carries details to the caller. Deliberate tradeoff per the issue's redaction requirement.

## Deliberate omissions

- `app/tgi/**` telemetry (raw `args` in `tool_service.py`) — known separate defect, follow-up proposed on issue #84.
- `resources/read`/`prompts/get` get no `_meta` trace injection: the MCP Python SDK (1.29) exposes `meta` only on `call_tool`.
- List operations keep lightweight spans (now token-safe); the canonical wide schema covers the three operations the issue names.
- Pre-existing `x-inxm-mcp-session` header/variable names are the repo's existing public API — untouched.
- Repo-root `opentelemetry/` **test stub** extended (`baggage`, `propagate`, `SpanKind`, `Status`) — test infra required by the seam.
- Noticed, not absorbed: the PR pipeline's Docker job builds the production stage, so BuildKit prunes the `testing` stage — `black --check` + app pytest never actually run in CI (follow-up proposed on issue #84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
