### PR TITLE
fix(auth): remove bridge client-ID gate

### DIFF
--- a/app/oauth/token_exchange.py
+++ b/app/oauth/token_exchange.py
@@ -79,17 +79,13 @@ def _get_jwks_client():
     return _jwks_client
 
 
-def verified_caller_claims(
-    token: str, *, allowed_clients: list, allowlist_name: str
-) -> Dict[str, Any]:
+def verified_caller_claims(token: str) -> Dict[str, Any]:
     """Verify a Keycloak token and return its claims, or fail closed.
 
     Enforces: signature against the realm JWKS, a present and valid exp,
     the exact configured issuer (KEYCLOAK_ISSUER, defaulting to
-    {AUTH_BASE_URL}/realms/{realm}), and that the token was issued to a
-    client in the caller-supplied allowlist (azp, falling back to aud).
-    Fails closed with UserLoggedOutException on any violation — including
-    an empty allowlist, so no client in the realm is trusted implicitly.
+    {AUTH_BASE_URL}/realms/{realm}). Fails closed with
+    UserLoggedOutException on any violation.
     The bridge accepts direct Bearer tokens (desktop clients bypass the
     ingress proxy), so any authorization decision based on token claims
     must go through this function, never an unverified decode.
@@ -113,6 +109,12 @@ def verified_caller_claims(
             f"Access token issued by unexpected issuer: {claims.get('iss')}"
         )
 
+    return claims
+
+
+def _ensure_allowlisted_client(
+    claims: Dict[str, Any], *, allowed_clients: list, allowlist_name: str
+) -> None:
     if not allowed_clients:
         raise UserLoggedOutException(
             f"{allowlist_name} is not configured; refusing to trust tokens "
@@ -126,16 +128,17 @@ def verified_caller_claims(
         raise UserLoggedOutException(
             f"Access token client(s) {token_clients} not in the allowlist"
         )
-    return claims
 
 
 def verified_keycloak_claims(token: str) -> Dict[str, Any]:
     """Verify a Keycloak token before it may release a stored credential."""
-    return verified_caller_claims(
-        token,
+    claims = verified_caller_claims(token)
+    _ensure_allowlisted_client(
+        claims,
         allowed_clients=USER_API_KEY_ALLOWED_CLIENTS,
         allowlist_name="USER_API_KEY_ALLOWED_CLIENTS",
     )
+    return claims
 
 
 class UserApiKeyTokenRetriever(TokenRetriever):

--- a/app/oauth/user_info.py
+++ b/app/oauth/user_info.py
@@ -305,9 +305,9 @@ def ensure_caller_in_required_groups(access_token: Optional[str]) -> None:
     No-op when BRIDGE_REQUIRED_GROUPS is unset. This gate is an authorization
     boundary, and the bridge deliberately accepts direct Bearer tokens
     (desktop clients bypass the ingress proxy) — so group membership is read
-    only from claims that passed signature (realm JWKS), expiry, exact-issuer
-    and client-allowlist (BRIDGE_ALLOWED_CLIENTS) verification. A forged but
-    syntactically valid JWT never reaches the group check.
+    only from claims that passed signature (realm JWKS), expiry, and exact
+    issuer verification. A forged but syntactically valid JWT never reaches
+    the group check.
     """
     from app import vars as app_vars
     from app.oauth.token_exchange import (
@@ -321,11 +321,7 @@ def ensure_caller_in_required_groups(access_token: Optional[str]) -> None:
     if not access_token:
         raise CallerNotAuthorizedError(401, "Authentication required")
     try:
-        claims = verified_caller_claims(
-            access_token,
-            allowed_clients=app_vars.BRIDGE_ALLOWED_CLIENTS,
-            allowlist_name="BRIDGE_ALLOWED_CLIENTS",
-        )
+        claims = verified_caller_claims(access_token)
     except UserLoggedOutException:
         raise CallerNotAuthorizedError(401, "Access token failed verification")
     data_manager = get_data_access_manager()

--- a/app/test_bridge_required_groups.py
+++ b/app/test_bridge_required_groups.py
@@ -53,9 +53,7 @@ def fake_verifier(monkeypatch):
     """Stand-in for JWKS verification: trusts the two well-known test tokens,
     rejects everything else — mirroring what real verification guarantees."""
 
-    def _verify(token, *, allowed_clients, allowlist_name):
-        if not allowed_clients:
-            raise UserLoggedOutException(f"{allowlist_name} is not configured")
+    def _verify(token):
         if token in (IN_GROUP_TOKEN, OUT_OF_GROUP_TOKEN):
             return jwt.decode(token, options={"verify_signature": False})
         raise UserLoggedOutException("Access token failed verification")
@@ -105,7 +103,6 @@ def client():
 @pytest.fixture
 def required_groups(monkeypatch):
     monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", ["operators"])
-    monkeypatch.setattr(app_vars, "BRIDGE_ALLOWED_CLIENTS", ["web-client"])
 
 
 @pytest.fixture
@@ -141,13 +138,11 @@ class TestGateUnit:
             ensure_caller_in_required_groups(FORGED_TOKEN)
         assert excinfo.value.status_code == 401
 
-    def test_unconfigured_client_allowlist_fails_closed(self, monkeypatch):
+    def test_group_gate_does_not_require_client_allowlist(
+        self, monkeypatch, fake_verifier
+    ):
         monkeypatch.setattr(app_vars, "BRIDGE_REQUIRED_GROUPS", ["operators"])
-        monkeypatch.setattr(app_vars, "BRIDGE_ALLOWED_CLIENTS", [])
-        monkeypatch.setattr(token_exchange, "_jwks_client", None)
-        with pytest.raises(CallerNotAuthorizedError) as excinfo:
-            ensure_caller_in_required_groups(IN_GROUP_TOKEN)
-        assert excinfo.value.status_code == 401
+        ensure_caller_in_required_groups(IN_GROUP_TOKEN)
 
     def test_out_of_group_is_403(self, required_groups, fake_verifier):
         with pytest.raises(CallerNotAuthorizedError) as excinfo:
@@ -170,9 +165,9 @@ class TestGateUnit:
 
 
 class TestVerifiedCallerClaims:
-    """The shared verifier itself: explicit client policy, signature-first."""
+    """The shared verifier itself: signature and issuer verification."""
 
-    def test_client_allowlist_is_explicit_per_caller(self, monkeypatch):
+    def test_returns_verified_claims(self, monkeypatch):
         from app.oauth.token_exchange import verified_caller_claims
 
         class OkJwks:
@@ -191,16 +186,8 @@ class TestVerifiedCallerClaims:
                 "azp": "bridge-client",
             },
         )
-        claims = verified_caller_claims(
-            "token", allowed_clients=["bridge-client"], allowlist_name="X"
-        )
+        claims = verified_caller_claims("token")
         assert claims["azp"] == "bridge-client"
-        with pytest.raises(UserLoggedOutException):
-            verified_caller_claims(
-                "token", allowed_clients=["other"], allowlist_name="X"
-            )
-        with pytest.raises(UserLoggedOutException):
-            verified_caller_claims("token", allowed_clients=[], allowlist_name="X")
 
 
 class TestRestGate:

--- a/app/vars.py
+++ b/app/vars.py
@@ -231,20 +231,12 @@ MCP_TRACE_BAGGAGE_ALLOWLIST = [
 # not only its ingress — enforces the authorization boundary: an
 # authenticated caller outside these groups gets 403 before any downstream
 # contact. Group membership is read from VERIFIED claims only (signature via
-# the realm JWKS, expiry, exact issuer, and the client allowlist below): the
+# the realm JWKS, expiry and exact issuer): the
 # bridge accepts direct Bearer tokens, so a forged unsigned token must never
 # pass this gate.
 BRIDGE_REQUIRED_GROUPS = [
     g.strip() for g in os.getenv("BRIDGE_REQUIRED_GROUPS", "").split(",") if g.strip()
 ]
-# Clients whose tokens the group gate accepts (matched against azp, falling
-# back to aud). REQUIRED whenever BRIDGE_REQUIRED_GROUPS is set — with no
-# allowlist the gate fails closed rather than trusting any client in the
-# realm (same idiom as USER_API_KEY_ALLOWED_CLIENTS).
-BRIDGE_ALLOWED_CLIENTS = [
-    c.strip() for c in os.getenv("BRIDGE_ALLOWED_CLIENTS", "").split(",") if c.strip()
-]
-
 # Ceiling on the JSON-encoded size of a downstream tool result. 0 disables
 # the check. Some downstream MCP servers enforce count-based limits, which do
 # not bound every serialized response, so the bridge has its own byte cap.


### PR DESCRIPTION
## Why

All first-party MCP clients may use the bridge. Client ID is not an authorization boundary here; verified Keycloak identity plus BRIDGE_REQUIRED_GROUPS is. Keeping a separate caller allowlist adds configuration and an avoidable outage mode.

## Change

- remove BRIDGE_ALLOWED_CLIENTS from the bridge authorization path
- retain JWKS signature, expiry, and exact issuer validation before checking groups
- retain USER_API_KEY_ALLOWED_CLIENTS for the separate stored user-API-key release path

## Verification

uv run --project app --extra dev pytest app/test_bridge_required_groups.py app/oauth/test_user_api_key_retriever.py (30 passed)

Paired with https://github.com/inxm-ai/mcp-jaeger-server/pull/2, which removes the obsolete Helm/playbook setting.